### PR TITLE
Bug Fix: 0929042, 0929087, 0929088

### DIFF
--- a/playbooks/02 - Use Case - IT OT Asset Management/Links Assets To Alert.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Links Assets To Alert.json
@@ -25,7 +25,9 @@
                     "destinationIPAddress": "{{vars.input.records[0].destinationIp}}"
                 },
                 "apply_async": false,
-                "step_variables": [],
+                "step_variables": {
+                    "assetIRIList": "{% set IRIList = [] %}{% if vars.steps.Find_Assets['sourceAsset'] != \"\" %}{% set _ = IRIList.append(vars.steps.Find_Assets['sourceAsset']) %}{% endif %}{% if vars.steps.Find_Assets['destinationAsset'] != \"\" %}{% set _ = IRIList.append(vars.steps.Find_Assets['destinationAsset']) %}{% endif %}{{IRIList}}"
+                },
                 "pass_parent_env": false,
                 "pass_input_record": false,
                 "workflowReference": "\/api\/3\/workflows\/9a71aada-d52d-414a-af6a-8e14e3877907"
@@ -44,7 +46,7 @@
             "arguments": {
                 "resource": {
                     "__link": {
-                        "assets": "{{vars.steps.Find_Assets['sourceAsset'], vars.steps.Find_Assets['destinationAsset']}}"
+                        "assets": "{{vars.assetIRIList}}"
                     }
                 },
                 "_showJson": false,

--- a/playbooks/02 - Use Case - IT OT Asset Management/Quarantine Asset and Raise Ticket.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Quarantine Asset and Raise Ticket.json
@@ -38,7 +38,15 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.3",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Quarantine Asset and Raise Ticket'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
+                "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -196,7 +204,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Isolated Following Assets and Raised ServiceNow Ticket : <span class=\"badge badge-pill badge-danger\" style=\"background: #009d00; color: #fff;\">{{vars.result.data.result.number}}<\/span><\/p>\n<p>{% for asset in vars.assetList %}<\/p>\n<ul>\n<li>{{asset.hostname}}<\/li>\n<\/ul>\n<p>{% endfor %}<\/p>",
+                    "content": "<p><span style=\"background-color: orange; color: black; border-radius: 4px; font-size: 5mm;\"><span style=\"font-size: 15px; font-weight: bold; font-family: 'Georgia', monospace;\">\ud83d\udca1Note <br \/><\/span><\/span> Isolated Following Assets and Raised ServiceNow Ticket : <span class=\"badge badge-pill badge-danger\" style=\"background: #009d00; color: #fff;\">{{vars.result.data.result.number}}<\/span><\/p>\n<p>{% for asset in vars.assetList %}<\/p>\n<ul>\n<li><a href=\"\/modules\/assets\/{{asset.uuid}}\" target=\"_blank\" rel=\"noopener\">{{asset.hostname}}<\/a><\/li>\n<\/ul>\n<p>{% endfor %}<\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "version": "3.2.0",

--- a/playbooks/02 - Use Case - IT OT Asset Management/Set Asset Icon.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Set Asset Icon.json
@@ -132,6 +132,7 @@
     "recordTags": [
         "Asset",
         "Asset Resources",
-        "Icon"
+        "Icon",
+        "IT OT"
     ]
 }


### PR DESCRIPTION
Descriptions: 
1. OT asset management: Links Assets To Alert PB is failing when source and destination value are not found.
2. OT asset management: Need to add a comment with user details when the Quarantine Asset and Raise Ticket is cancelled
3. OT asset management: OT/IT tag is missing in the Set Asset Icon PB.

Fix:
1. In playbook "Links Assets To Alert" added a variable as a list and appending asset IRI if it not null.
2. Added IT OT tag in "Set Asset Icon" PB.
3. Added comment on cancelling the playbook and added hyperlink for assets

