### PR TITLE
Bug Fixes: 0930734, 0930319, 0930736, 0930744, 0930751

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -79,22 +79,17 @@ The simulation mode has some sample data that helps you get a better understandi
 
 - Browse to `Simulations` > `OT - Add Sample Asset Change Activity Record` scenario and click **Simulate Scenario**.
 
-- Playbook: **Scenario - OT - Asset Change Activity** has two variables `dueDays` and `mediumImpactAsset`. You can populate these variables with your preferred values in the *Configuration* step. 
-    - `dueDays` - Days required to complete change activity.
-    - `mediumImpactAsset` - Impacted Asset hostname.
+    >**NOTE**: Playbook: **Scenario - OT - Asset Change Activity** has variable `dueDays` (*Days required to complete change activity*). You can populate these variables with your preferred values in the *Configuration* step.
 
 - With a given value of due date in `dueDays` two Asset Change Activity entries are made.
-    - Add New Cyber Asset - Intel Core i7-13700K (Asset) 
-    - Medium Impact Baseline Change - Patch For log 4J
-
-- If an asset does not already exist, it is created and added to the record with the following hostname:
-    - Intel Core i7-13700K
+    - Add New Cyber Asset - Siemens S7-400-S621
+    - Medium Impact Baseline Change - Stratix 5950-RW41
 
 - Assets are linked and can be seen in the Assets & Vulnerabilities tab.
 
 - Once the record has been created, execute the **Add Task From Templates** to assign different tasks to different people. 
 
-- New tasks get created once the previous task is completed.
+- New tasks get created as priority `Medium` once the previous task is completed.
 
 - New task can be added by using **Add New Task** playbook.
 

--- a/info.json
+++ b/info.json
@@ -2,13 +2,6 @@
     "name": "oT-AssetManagement",
     "version": "2.0.0",
     "fsrMinCompatibility": "7.4.1",
-    "featuredTags": [
-        {
-            "color": "#2d87e3",
-            "tag": "preview"
-        }
-    ],
-    "featured": true,
     "type": "solutionpack",
     "local": true,
     "label": "OT - Asset Management",

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -33,6 +33,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -69,6 +70,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -6932,6 +6934,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -6968,6 +6971,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7057,6 +7061,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7093,6 +7098,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7297,6 +7303,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7333,6 +7340,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7369,6 +7377,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -7405,6 +7414,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -33,6 +33,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -45,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "218",
+            "top": "1120",
+            "left": "480",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "ae490276-c33a-4735-80b5-0c834c27f510"
@@ -5265,6 +5266,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5354,6 +5356,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5390,6 +5393,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5566,6 +5570,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5602,6 +5607,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5638,6 +5644,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -33,6 +33,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5277,6 +5278,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5366,6 +5368,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5402,6 +5405,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5579,6 +5583,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5615,6 +5620,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5651,6 +5657,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -33,6 +33,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5277,6 +5278,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5366,6 +5368,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5402,6 +5405,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5579,6 +5583,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5615,6 +5620,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5651,6 +5657,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -33,6 +33,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5277,6 +5278,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5366,6 +5368,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5402,6 +5405,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5579,6 +5583,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5615,6 +5620,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],
@@ -5651,6 +5657,7 @@
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
                     ],

--- a/playbooks/02 - Use Case - Asset Change Activity/collection.metadata.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/collection.metadata.json
@@ -7,5 +7,7 @@
     "image": null,
     "uuid": "0dc98705-9053-4d76-8a44-b73cf7f06666",
     "deletedAt": null,
-    "recordTags": []
+    "recordTags": [
+        "IT OT"
+    ]
 }

--- a/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Create Alerts Record.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Create Alerts Record.json
@@ -37,6 +37,7 @@
                     "sourceId": "{{vars.item['Id']}}",
                     "sourceIp": "{{vars.item['Source IP']}}",
                     "__replace": "true",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
                     "recordTags": "{{vars.item['Tags']}}",
                     "sourcePort": "{{vars.item['Source Port']}}",
                     "description": "{{vars.item['Description']}}",

--- a/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Stuxnet Attack Scenario.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Stuxnet Attack Scenario.json
@@ -43,6 +43,7 @@
                     "severity": "\/api\/3\/picklists\/58d0753f-f7e4-403b-953c-b0f521eab759",
                     "sourceIp": "110.132.30.51",
                     "__replace": "false",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
                     "recordTags": [
                         "\/api\/3\/tags\/Sample",
                         "\/api\/3\/tags\/IT OT"
@@ -91,6 +92,7 @@
                     "severity": "\/api\/3\/picklists\/58d0753f-f7e4-403b-953c-b0f521eab759",
                     "sourceIp": "110.132.30.63",
                     "__replace": "true",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
                     "recordTags": [
                         "\/api\/3\/tags\/IT OT",
                         "\/api\/3\/tags\/Sample"
@@ -334,6 +336,7 @@
                     "severity": "\/api\/3\/picklists\/58d0753f-f7e4-403b-953c-b0f521eab759",
                     "sourceIp": "110.132.30.51",
                     "__replace": "false",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
                     "recordTags": [
                         "\/api\/3\/tags\/Sample",
                         "\/api\/3\/tags\/IT OT"
@@ -381,6 +384,7 @@
                     "severity": "\/api\/3\/picklists\/58d0753f-f7e4-403b-953c-b0f521eab759",
                     "sourceIp": "110.132.30.72",
                     "__replace": "false",
+                    "assignedTo": "\/api\/3\/people\/3451141c-bac6-467c-8d72-85e0fab569ce",
                     "recordTags": [
                         "\/api\/3\/tags\/Sample",
                         "\/api\/3\/tags\/IT OT"

--- a/playbooks/02 - Use Case - IT OT Asset Management/collection.metadata.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/collection.metadata.json
@@ -7,5 +7,7 @@
     "image": null,
     "uuid": "fb4aa534-4bfc-4196-b509-96ef02fb9270",
     "deletedAt": null,
-    "recordTags": []
+    "recordTags": [
+        "IT OT"
+    ]
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,7 +22,7 @@
 
 - Changed tag name from `SampleAsset` & `SampleAlert` to `Sample`
 - Added connector `Qualys` in Solution Pack.
-- Under dashbaord **Asset Overview** changed widget name from `MEF Asset` to `Most Essential Function (MEF) Assets`
+- Under dashboard **Asset Overview** changed widget name from `MEF Asset` to `Most Essential Function (MEF) Assets`
 - Renamed playbook `Links MITRE Matrices To Alert` to `Links Assets To Alert` and removed MITRE Module data correlation as implemented same in **MITRE ATT&CK Enrichment Framework v2.2.0**
 
 ## Depreciated


### PR DESCRIPTION
Descriptions:
1. OT asset management: Duplicate steps mentioned in doc, due to which multiple same entries are created
2. OT asset management: Typo in documentation under bugs section.
3. OT asset management: Tags IT/OT missing in both asset management collection.
4. Ot asset management: Need to set the priority for each task if created from template for filter to work.
5. Ot asset management: Asset risk overview dashboard alerts need to be assigned to some default user

Fix:
1. Update usage sequence for Asset Change Activity in usage.md
2. Added priority as "Medium" for all type of task created for Asset Change Activity.
3. Added IT OT tag in Playbook collections.
4. Assigned CS Admin user for Simulation Alerts.


