### PR TITLE
Bug Fixes:

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,10 @@
 # Release Information
 
-* **Version**: 2.0.0 <sup>Preview</sup>
+* **Version**: 2.0.0
 * **Certified**: Yes
 * **Publisher**: Fortinet
 * **Compatible Version**: Minimum compatible FortiSOAR v7.4.1
 * [Release Notes](./release_notes.md)
-
->**NOTE**: Preview releases are a beta release. This means that release is intended to get feedback and might not be best suited for production level deployments. The functionality might change in backward-incompatible ways or have limited support. A beta release is not subject to any SLA, Quality Assurance or deprecation policy. Feature availability and support for preview releases will continue to improve as the solution/feature matures.
 
 # Overview
 

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5785,7 +5785,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5822,7 +5822,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5859,7 +5859,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7"
                 },
@@ -32,6 +32,7 @@
                     "name": "Approver Approval To Implement - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -45,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "218",
+            "top": "1500",
+            "left": "780",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "a203fe02-2ea7-4ace-85d3-680ee2de15b1"
@@ -5268,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c"
                 },
@@ -5276,6 +5277,7 @@
                     "name": "Assignee Approval To Implement - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5289,11 +5291,214 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "125",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "890ce319-249e-477b-9523-1de9ca1c30f7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1640",
+            "left": "780",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "2273962c-205a-4f44-98d3-70a49644a5ab"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "4ef24254-7fe0-4dcf-9f4b-f4749fd15374"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "6264b2f6-2107-405f-90d4-e7c112367297"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2460",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "258a8617-5365-477c-b361-dcd1f160c5d4"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "4b618c04-52e3-48be-8ba2-4c9c2c802f34"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "621fa6d9-f860-4d9f-9ab2-e66bd06c229c"
         },
         {
             "@type": "WorkflowStep",
@@ -5301,7 +5506,15 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5309,7 +5522,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "475",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "f9702fdc-d0b4-4327-b32c-8f82780d5419"
@@ -5339,7 +5552,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -5358,13 +5572,14 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
                     "name": "Identify Security Control - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5379,7 +5594,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "5c0f5211-e831-4154-b953-80b9ef18f195"
@@ -5393,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5401,6 +5616,7 @@
                     "name": "Implement Change - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5414,8 +5630,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
-            "left": "125",
+            "top": "1785",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "71087f79-c97f-4aed-b1d5-2b2d60b92770"
@@ -5441,8 +5657,8 @@
                 ]
             },
             "status": null,
-            "top": "975",
-            "left": "125",
+            "top": "1380",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "67aecd80-a9f8-4747-9e54-a388292d685b"
@@ -5466,8 +5682,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
-            "left": "125",
+            "top": "2595",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "edd0ecea-2c5c-416d-ab47-1632976f0a93"
@@ -5491,7 +5707,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "71e76e23-0120-453a-9659-7db2589ae6a4"
@@ -5569,7 +5785,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5577,6 +5793,7 @@
                     "name": "Update Baseline - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5590,8 +5807,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
-            "left": "125",
+            "top": "2325",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "6eb87ce4-0501-4ea8-adee-721a49355316"
@@ -5605,7 +5822,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5613,6 +5830,7 @@
                     "name": "Verify Security Controls - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5626,8 +5844,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "125",
+            "top": "2055",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "c9a6277b-61f3-433d-83fe-ab2713055593"
@@ -5641,7 +5859,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195"
                 },
@@ -5649,6 +5867,7 @@
                     "name": "Verify Software Source - {{vars.input.records[0].title}}",
                     "dueBy": "{{vars.input.records[0].dueDate}}",
                     "assets": "{{vars.assetIRI}}",
+                    "priority": "\/api\/3\/picklists\/539083a6-01f6-4ff9-a588-778cfdad4671",
                     "status": "\/api\/3\/picklists\/7669725a-28cc-4b19-98a3-9ca71e0f88f4",
                     "recordTags": [
                         "\/api\/3\/tags\/AssetChangeActivity"
@@ -5662,8 +5881,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
-            "left": "125",
+            "top": "840",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "d078e144-56e0-4cfa-bb33-a723aa7f2b0c"
@@ -5682,13 +5901,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
+            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
             "sourceStep": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c01f64e2-2b29-4a5b-bc62-f087a8ff1708"
+            "uuid": "9f4c0328-6455-45e4-a8aa-86b801affbdd"
         },
         {
             "@type": "WorkflowRoute",
@@ -5702,63 +5921,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
+            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
             "sourceStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "7c653ab2-0f7e-4326-b8ee-81a895052644"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
-            "sourceStep": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "e897e1ab-dfd8-4168-bc66-119de1b24284"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
-            "sourceStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "f35c760f-2467-4aab-ac72-d5b2aede704e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/edd0ecea-2c5c-416d-ab47-1632976f0a93",
-            "sourceStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "355b4476-f53b-4ec9-9c99-71518909cb5c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
-            "sourceStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "76d122b6-27be-40fe-8c48-ad2ef8951c2c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Software Source -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
-            "sourceStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "8164f910-d059-4948-8da1-4b9f87dcdd93"
+            "uuid": "865e5895-a9a4-4139-bfb8-fbb332ef8413"
         },
         {
             "@type": "WorkflowRoute",
@@ -5782,6 +5951,76 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
+            "sourceStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d944500c-caa6-495d-8b69-aed7428fe6d6"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
+            "sourceStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "03731ae1-3811-493c-bca5-2863a93c680b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
+            "sourceStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "51209993-29c8-4741-8669-4151ce346877"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
+            "sourceStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "cd5d54c5-6f7e-4605-896d-8524c493d8c3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/edd0ecea-2c5c-416d-ab47-1632976f0a93",
+            "sourceStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "22d11a67-5beb-4746-88d1-d585edf7b735"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
+            "sourceStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d6882b09-1466-40c2-a1d8-78da9d656cd7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
+            "sourceStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0cd7af78-11b2-4779-91d1-8f88962038ba"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy of Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "sourceStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
@@ -5802,6 +6041,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
+            "sourceStep": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6783f4b8-1538-4278-80f5-2860398e6904"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
+            "sourceStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b752de7f-96d6-492a-a153-9c841adab1a3"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Get Correlated Asset",
             "targetStep": "\/api\/3\/workflow_steps\/60754010-8a9b-451d-935c-c1440fc796d1",
             "sourceStep": "\/api\/3\/workflow_steps\/1b351a82-c6f3-4b77-b95e-08a9a619c50d",
@@ -5809,6 +6068,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "411837f8-266d-4625-8191-3a1d6bca690d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
+            "sourceStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9885034f-d88d-4088-ab8a-08b1f9ed71c4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
+            "sourceStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e5b01302-1787-43a0-9a9c-96cf95c1dea4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
+            "sourceStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "489059da-6af7-441b-822d-2540ea824c2e"
         }
     ],
     "groups": [],
@@ -5818,9 +6107,9 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "ManualTrigger",
         "Add Cyber Asset",
         "Asset Change Activity",
-        "IT OT"
+        "IT OT",
+        "ManualTrigger"
     ]
 }

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comments on asset as Approver Approval To Implement task completed",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comments on asset as Assignee Approval To Implement task completed",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comments on asset as Identify Security Control task completed",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comments on asset as Implement Change Task task completed",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comments on asset as Update Baseline task completed",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comments on asset as Verify Security Controls task completed",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comments on asset as Verify Software Source task completed",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5901,7 +5901,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
             "sourceStep": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1",
             "label": null,
@@ -5921,7 +5921,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
             "sourceStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
             "label": null,
@@ -5951,7 +5951,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "sourceStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
             "label": null,
@@ -5961,7 +5961,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
             "sourceStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
             "label": null,
@@ -5971,7 +5971,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
             "sourceStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
             "label": null,
@@ -5981,7 +5981,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
             "sourceStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
             "label": null,
@@ -5991,7 +5991,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/edd0ecea-2c5c-416d-ab47-1632976f0a93",
             "sourceStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
             "label": null,
@@ -6001,7 +6001,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
             "sourceStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
             "label": null,
@@ -6011,7 +6011,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
             "sourceStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
             "label": null,
@@ -6041,7 +6041,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
             "sourceStep": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195",
             "label": null,
@@ -6051,7 +6051,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Implement Change Task Complete",
+            "name": "Implement Change -> Insert Comment Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
             "sourceStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "label": null,
@@ -6071,7 +6071,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Update Baseline Task Complete",
+            "name": "Update Baseline -> Insert Comment Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
             "sourceStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
             "label": null,
@@ -6081,7 +6081,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
             "sourceStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
             "label": null,
@@ -6091,7 +6091,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
             "sourceStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1500",
-            "left": "780",
+            "top": "1520",
+            "left": "820",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "a203fe02-2ea7-4ace-85d3-680ee2de15b1"
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c"
                 },
@@ -5320,8 +5320,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1640",
-            "left": "780",
+            "top": "1660",
+            "left": "820",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "2273962c-205a-4f44-98d3-70a49644a5ab"
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" rel=\"noopener\" target=\"_blank\" >{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5785,7 +5785,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5822,7 +5822,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1"
                 },
@@ -5859,7 +5859,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comments on asset as Approver Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comments on asset as Assignee Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comments on asset as Identify Security Control task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comments on asset as Implement Change Task task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comments on asset as Update Baseline task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comments on asset as Verify Security Controls task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comments on asset as Verify Software Source task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5901,7 +5901,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
             "sourceStep": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1",
             "label": null,
@@ -5921,7 +5921,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
             "sourceStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
             "label": null,
@@ -5941,7 +5941,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/a203fe02-2ea7-4ace-85d3-680ee2de15b1",
             "sourceStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
             "label": "Yes",
@@ -5951,7 +5951,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "sourceStep": "\/api\/3\/workflow_steps\/2273962c-205a-4f44-98d3-70a49644a5ab",
             "label": null,
@@ -5961,7 +5961,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
             "sourceStep": "\/api\/3\/workflow_steps\/4ef24254-7fe0-4dcf-9f4b-f4749fd15374",
             "label": null,
@@ -5971,7 +5971,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
             "sourceStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
             "label": null,
@@ -5981,7 +5981,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "name": "Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
             "sourceStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
             "label": null,
@@ -5991,7 +5991,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/edd0ecea-2c5c-416d-ab47-1632976f0a93",
             "sourceStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
             "label": null,
@@ -6001,7 +6001,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
             "sourceStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
             "label": null,
@@ -6011,7 +6011,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/890ce319-249e-477b-9523-1de9ca1c30f7",
             "sourceStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
             "label": null,
@@ -6021,7 +6021,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Check Approver 2 -> Implement Change",
+            "name": "Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "sourceStep": "\/api\/3\/workflow_steps\/67aecd80-a9f8-4747-9e54-a388292d685b",
             "label": "No",
@@ -6041,7 +6041,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7dc0d67f-17c8-448c-b66e-8ec8e5d3b6b7",
             "sourceStep": "\/api\/3\/workflow_steps\/5c0f5211-e831-4154-b953-80b9ef18f195",
             "label": null,
@@ -6051,7 +6051,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "name": "Implement Change -> Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6264b2f6-2107-405f-90d4-e7c112367297",
             "sourceStep": "\/api\/3\/workflow_steps\/71087f79-c97f-4aed-b1d5-2b2d60b92770",
             "label": null,
@@ -6071,7 +6071,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "name": "Update Baseline -> Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/258a8617-5365-477c-b361-dcd1f160c5d4",
             "sourceStep": "\/api\/3\/workflow_steps\/6eb87ce4-0501-4ea8-adee-721a49355316",
             "label": null,
@@ -6081,7 +6081,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4b618c04-52e3-48be-8ba2-4c9c2c802f34",
             "sourceStep": "\/api\/3\/workflow_steps\/c9a6277b-61f3-433d-83fe-ab2713055593",
             "label": null,
@@ -6091,7 +6091,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/621fa6d9-f860-4d9f-9ab2-e66bd06c229c",
             "sourceStep": "\/api\/3\/workflow_steps\/d078e144-56e0-4cfa-bb33-a723aa7f2b0c",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Add New Task.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add New Task.json
@@ -960,7 +960,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">{{vars.steps.Add_Task_Details.input.name}} - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task <a href=\"\/modules\/tasks\/{{vars.steps.Create_Task_and_Correlate.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Create_Task_and_Correlate.name}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -61,7 +61,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Test'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Test.name}}<\/a> to <strong>'Approver Approval To Test'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d"
                 },
@@ -6925,7 +6925,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
+                    "content": "<p>Added Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -6962,7 +6962,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Test'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Test.name}}<\/a> to <strong>'Assignee Approval To Test'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333"
                 },
@@ -7352,7 +7352,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -7388,7 +7388,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7593,7 +7593,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Test Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Test_Security_Controls.name}}<\/a> to <strong>'Test Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -7630,7 +7630,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7667,7 +7667,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7704,7 +7704,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
-            "left": "383",
+            "top": "2440",
+            "left": "840",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "3519deaa-67e1-4d4d-9762-acccaa230c54"
@@ -61,7 +61,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Approver Approval To Test - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Test'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d"
                 },
@@ -83,8 +83,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "383",
+            "top": "1500",
+            "left": "780",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "19904d3f-0099-47f5-bd71-e91498293e2d"
@@ -6925,7 +6925,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -6947,7 +6947,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "2055",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -6962,7 +6962,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Test - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Test'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333"
                 },
@@ -6984,7 +6984,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -6992,11 +6992,309 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2580",
+            "left": "840",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "7e847c16-1995-45ea-bdac-248255525e42"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Test Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Test['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1640",
+            "left": "780",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "310db978-21fa-407c-b349-24fe7665e439"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "5c563fbc-5829-4193-b056-937739b19479"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Test Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Test['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "1885a1ec-b97a-4bcb-af4b-2fdfe8cef360"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "d60aca35-f7ea-44b5-bdd3-d61e1c2858a5"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2865",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "e38c55e5-50e4-4f2b-b3a9-c6176036d10c"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Test Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Test_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "a9aacf0c-0d63-4daf-9078-ceab0641ea87"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "3405",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "7bca8384-8fc9-4ebe-9954-72360ac7160d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "3135",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "b69d6f90-aa8a-40b1-96a0-162a837a13d9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "ec346191-4440-4a3a-8a1b-164ef6e94d8f"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Do Nothing",
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -7034,7 +7332,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -7053,7 +7352,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -7089,7 +7388,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7111,7 +7410,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1785",
+            "top": "2730",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -7138,7 +7437,7 @@
                 ]
             },
             "status": null,
-            "top": "1515",
+            "top": "2325",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -7165,7 +7464,7 @@
                 ]
             },
             "status": null,
-            "top": "975",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -7190,7 +7489,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2190",
+            "top": "3540",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -7294,7 +7593,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Test Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Test Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -7316,7 +7615,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1785",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -7331,7 +7630,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7353,7 +7652,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "2055",
+            "top": "3270",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -7368,7 +7667,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7390,7 +7689,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1920",
+            "top": "3000",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -7405,7 +7704,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d"
                 },
@@ -7427,7 +7726,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -7447,23 +7746,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
+            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
             "sourceStep": "\/api\/3\/workflow_steps\/3519deaa-67e1-4d4d-9762-acccaa230c54",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e454cebf-f7a8-45c1-9451-b6b4918ccf3d"
+            "uuid": "bb8e9903-768f-4593-8628-0eb38e9abb67"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Test -> Test Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
+            "name": "Approver Approval To Test -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
             "sourceStep": "\/api\/3\/workflow_steps\/19904d3f-0099-47f5-bd71-e91498293e2d",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "c3eb0353-b6e1-4dbc-a3b9-1e7dfb5ffd3c"
+            "uuid": "4f650728-e1f6-4f8f-a912-d1d31199fbd5"
         },
         {
             "@type": "WorkflowRoute",
@@ -7477,53 +7776,23 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/da191e8f-6dbb-4209-8729-b66270a67053",
+            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
             "sourceStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "99e504c4-ac74-4b79-95ce-22d6debba340"
+            "uuid": "dbdccd4a-9bf2-43e1-a14e-32fa65ae6429"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
-            "sourceStep": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d",
+            "name": "Assignee Approval To Test -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
+            "sourceStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "cd95468e-32f2-4f7d-9eee-0d9c4aaa80c4"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
-            "sourceStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "8d0768af-23e6-4e2d-89bd-e947b3f27630"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/462fd673-2ba3-4a00-a70a-ce00fc3796fe",
-            "sourceStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "20880d86-d823-422a-a51b-235e85603436"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
-            "sourceStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "fad42e76-d781-4c16-be2b-c0bf11674221"
+            "uuid": "547d0931-3349-47cb-9cc9-917469e2a08a"
         },
         {
             "@type": "WorkflowRoute",
@@ -7547,6 +7816,96 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
+            "sourceStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5bd13eea-9025-4ab4-85d1-febdbb6745d7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Test Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
+            "sourceStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f2e41d08-2504-43eb-bd00-a4fc33e5be8e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/da191e8f-6dbb-4209-8729-b66270a67053",
+            "sourceStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "00010a2d-d01e-4984-b438-06b3a3deba66"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned for testing",
+            "targetStep": "\/api\/3\/workflow_steps\/63692e13-58e2-45b1-a729-f571fd1d5f3e",
+            "sourceStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3113421a-e320-4bc6-9259-e1550f7a789b"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
+            "sourceStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3be84f81-54e7-4ecd-b262-fc75238d2b29"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
+            "sourceStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "056ca1ee-7029-4192-a3f6-180dde656a70"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/462fd673-2ba3-4a00-a70a-ce00fc3796fe",
+            "sourceStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3e99e742-9eea-4e9d-9e40-d2906cc3d4bb"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
+            "sourceStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "67b04adc-5291-486f-80fe-4bd3751f1d06"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Test",
+            "targetStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
+            "sourceStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "08f630ce-7a18-4bea-a1a8-f034c11c35be"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy 1 of Is Approver Assigned -> Copy 1 of Approver Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/19904d3f-0099-47f5-bd71-e91498293e2d",
             "sourceStep": "\/api\/3\/workflow_steps\/63692e13-58e2-45b1-a729-f571fd1d5f3e",
@@ -7557,13 +7916,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Assignee Approval To Implement -> Copy 1 of Is Approver Assigned",
-            "targetStep": "\/api\/3\/workflow_steps\/63692e13-58e2-45b1-a729-f571fd1d5f3e",
-            "sourceStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
+            "name": "Copy of Comment Approver Approval To Test Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
+            "sourceStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "d8278e2b-fb17-4e7e-803a-c3553f2fd6b4"
+            "uuid": "e0bfb77b-d906-46bd-9148-6955261d5a86"
         },
         {
             "@type": "WorkflowRoute",
@@ -7574,6 +7933,26 @@
             "isExecuted": false,
             "group": null,
             "uuid": "2b7a7b81-6107-46b4-a4aa-6747b2c16c2a"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
+            "sourceStep": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4e68c423-842a-417d-bac5-dea399443b93"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
+            "sourceStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "27b547bc-80b9-47d5-a408-337b8fdaeae6"
         },
         {
             "@type": "WorkflowRoute",
@@ -7607,23 +7986,43 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Test Security Controls -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
+            "name": "Test Security Controls -> Copy of Comment Approver Approval To Test Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "sourceStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "0b47dd68-6307-48b5-94a8-a0f703f193c3"
+            "uuid": "74540365-fe61-4676-abb5-76a6eb58f2a6"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Assignee Approval To Test",
-            "targetStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
+            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
+            "sourceStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f0295f2e-2f68-4313-ab21-df88d5f35f71"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
+            "sourceStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "60c49d1a-97a7-480b-8fc7-15b95f6ae482"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
             "sourceStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "9bb3d467-58b5-429e-9ee7-3d1603d05389"
+            "uuid": "81f71935-8d8c-4a6c-945a-bf33d18d20b6"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -6992,8 +6992,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comments on asset as Approver Approval To Implement task complete",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7021,8 +7021,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Test Task Complete",
-            "description": "Comments on asset as Approver Approval To Test task complete",
+            "name": "Insert Comment Approver Approval To Test Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7050,8 +7050,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comments on asset as Assignee Approval To Implement task complete",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7079,8 +7079,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Test Task Complete",
-            "description": "Comments on asset as Assignee Approval To Test task complete",
+            "name": "Insert Comment Assignee Approval To Test Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7108,8 +7108,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comments on asset as Identify Security Control task complete",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7137,8 +7137,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comments on asset as Implement Change task complete",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7166,8 +7166,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Test Security Controls Task Complete",
-            "description": "Comments on asset as Test Security Controls task complete",
+            "name": "Insert Comment Test Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7195,8 +7195,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comments on asset as Update Baseline task complete",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7224,8 +7224,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comments on asset as Verify Security Controls task complete",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7253,8 +7253,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comments on asset as Verify Software Source task complete",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7746,7 +7746,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
             "sourceStep": "\/api\/3\/workflow_steps\/3519deaa-67e1-4d4d-9762-acccaa230c54",
             "label": null,
@@ -7756,7 +7756,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Test -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Test -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
             "sourceStep": "\/api\/3\/workflow_steps\/19904d3f-0099-47f5-bd71-e91498293e2d",
             "label": null,
@@ -7776,7 +7776,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
             "sourceStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
             "label": null,
@@ -7786,7 +7786,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Test -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Test -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
             "sourceStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
             "label": null,
@@ -7816,7 +7816,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
             "sourceStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
             "label": null,
@@ -7826,7 +7826,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Test Security Controls",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Test Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
             "sourceStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
             "label": null,
@@ -7836,7 +7836,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/da191e8f-6dbb-4209-8729-b66270a67053",
             "sourceStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
             "label": null,
@@ -7846,7 +7846,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned for testing",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned for testing",
             "targetStep": "\/api\/3\/workflow_steps\/63692e13-58e2-45b1-a729-f571fd1d5f3e",
             "sourceStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
             "label": null,
@@ -7856,7 +7856,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
             "sourceStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
             "label": null,
@@ -7866,7 +7866,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
             "sourceStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
             "label": null,
@@ -7876,7 +7876,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/462fd673-2ba3-4a00-a70a-ce00fc3796fe",
             "sourceStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
             "label": null,
@@ -7886,7 +7886,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
             "sourceStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
             "label": null,
@@ -7896,7 +7896,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Test",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Test",
             "targetStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
             "sourceStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
             "label": null,
@@ -7916,7 +7916,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Test Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Approver Approval To Test Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
             "sourceStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "label": null,
@@ -7936,7 +7936,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
             "sourceStep": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d",
             "label": null,
@@ -7946,7 +7946,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Implement Change Task Complete",
+            "name": "Implement Change -> Insert Comment Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
             "sourceStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
             "label": null,
@@ -7986,7 +7986,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Test Security Controls -> Approver Approval To Test Task Complete",
+            "name": "Test Security Controls -> Insert Comment Approver Approval To Test Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "sourceStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
             "label": null,
@@ -7996,7 +7996,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Update Baseline Task Complete",
+            "name": "Update Baseline -> Insert Comment Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
             "sourceStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
             "label": null,
@@ -8006,7 +8006,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
             "sourceStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
             "label": null,
@@ -8016,7 +8016,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
             "sourceStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -6992,8 +6992,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comments on asset as Approver Approval To Implement task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7021,8 +7021,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Test Task Complete",
-            "description": null,
+            "name": "Approver Approval To Test Task Complete",
+            "description": "Comments on asset as Approver Approval To Test task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7050,8 +7050,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comments on asset as Assignee Approval To Implement task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7079,8 +7079,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Test Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Test Task Complete",
+            "description": "Comments on asset as Assignee Approval To Test task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7108,8 +7108,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comments on asset as Identify Security Control task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7137,8 +7137,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comments on asset as Implement Change task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7166,8 +7166,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Test Security Controls Task Complete",
-            "description": null,
+            "name": "Test Security Controls Task Complete",
+            "description": "Comments on asset as Test Security Controls task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7195,8 +7195,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comments on asset as Update Baseline task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7224,8 +7224,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comments on asset as Verify Security Controls task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7253,8 +7253,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comments on asset as Verify Software Source task complete",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -7746,7 +7746,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
             "sourceStep": "\/api\/3\/workflow_steps\/3519deaa-67e1-4d4d-9762-acccaa230c54",
             "label": null,
@@ -7756,7 +7756,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Test -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Test -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
             "sourceStep": "\/api\/3\/workflow_steps\/19904d3f-0099-47f5-bd71-e91498293e2d",
             "label": null,
@@ -7776,7 +7776,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
             "sourceStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
             "label": null,
@@ -7786,7 +7786,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Test -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Test -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
             "sourceStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
             "label": null,
@@ -7806,7 +7806,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/3519deaa-67e1-4d4d-9762-acccaa230c54",
             "sourceStep": "\/api\/3\/workflow_steps\/da191e8f-6dbb-4209-8729-b66270a67053",
             "label": "Yes",
@@ -7816,7 +7816,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
             "sourceStep": "\/api\/3\/workflow_steps\/7e847c16-1995-45ea-bdac-248255525e42",
             "label": null,
@@ -7826,7 +7826,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Test Security Controls",
+            "name": "Approver Approval To Implement Task Complete -> Test Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
             "sourceStep": "\/api\/3\/workflow_steps\/310db978-21fa-407c-b349-24fe7665e439",
             "label": null,
@@ -7836,7 +7836,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/da191e8f-6dbb-4209-8729-b66270a67053",
             "sourceStep": "\/api\/3\/workflow_steps\/5c563fbc-5829-4193-b056-937739b19479",
             "label": null,
@@ -7846,7 +7846,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned for testing",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned for testing",
             "targetStep": "\/api\/3\/workflow_steps\/63692e13-58e2-45b1-a729-f571fd1d5f3e",
             "sourceStep": "\/api\/3\/workflow_steps\/1885a1ec-b97a-4bcb-af4b-2fdfe8cef360",
             "label": null,
@@ -7856,7 +7856,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
             "sourceStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
             "label": null,
@@ -7866,7 +7866,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "name": "Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
             "sourceStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
             "label": null,
@@ -7876,7 +7876,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/462fd673-2ba3-4a00-a70a-ce00fc3796fe",
             "sourceStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
             "label": null,
@@ -7886,7 +7886,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
             "sourceStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
             "label": null,
@@ -7896,7 +7896,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Test",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Test",
             "targetStep": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d",
             "sourceStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
             "label": null,
@@ -7916,7 +7916,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Comment Approver Approval To Test Task Complete -> Assignee Approval To Implement",
+            "name": "Approver Approval To Test Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/b5dc49a0-4ad9-42da-aa40-fb4fd8b78079",
             "sourceStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "label": null,
@@ -7936,7 +7936,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d60aca35-f7ea-44b5-bdd3-d61e1c2858a5",
             "sourceStep": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d",
             "label": null,
@@ -7946,7 +7946,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "name": "Implement Change -> Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e38c55e5-50e4-4f2b-b3a9-c6176036d10c",
             "sourceStep": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df",
             "label": null,
@@ -7986,7 +7986,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Test Security Controls -> Copy of Comment Approver Approval To Test Task Complete",
+            "name": "Test Security Controls -> Approver Approval To Test Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/a9aacf0c-0d63-4daf-9078-ceab0641ea87",
             "sourceStep": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365",
             "label": null,
@@ -7996,7 +7996,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "name": "Update Baseline -> Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/7bca8384-8fc9-4ebe-9954-72360ac7160d",
             "sourceStep": "\/api\/3\/workflow_steps\/bd016b8a-cbbd-47a9-a376-5a72d1a15033",
             "label": null,
@@ -8006,7 +8006,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/b69d6f90-aa8a-40b1-96a0-162a837a13d9",
             "sourceStep": "\/api\/3\/workflow_steps\/f842e34a-00ae-4233-9734-f452a2b82f30",
             "label": null,
@@ -8016,7 +8016,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ec346191-4440-4a3a-8a1b-164ef6e94d8f",
             "sourceStep": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -61,7 +61,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Test'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Test'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/3558e78e-ba4c-4957-8b46-9f9c8c4e828d"
                 },
@@ -6925,7 +6925,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -6962,7 +6962,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Test'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Test.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Test'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/04275973-7376-4327-b6da-320f36246333"
                 },
@@ -7352,7 +7352,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -7388,7 +7388,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7593,7 +7593,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Test Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Test_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Test Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/db1be4c8-1ecd-49ea-8e67-b1e5d4e0d365"
                 },
@@ -7630,7 +7630,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7667,7 +7667,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/23aa85cb-18d7-4f82-975b-0c24566567df"
                 },
@@ -7704,7 +7704,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/5feeeea8-da89-4d11-8b16-a89cc0c3a56d"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Manage Asset Change Activity Closure.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Manage Asset Change Activity Closure.json
@@ -17,6 +17,102 @@
     "steps": [
         {
             "@type": "WorkflowStep",
+            "name": "Get All Incomplete Task",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "uuid",
+                            "value": "{{vars.input.records[0]['@id'].split('\/')[-1]}}",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ],
+                    "__selectFields": [
+                        "tasks"
+                    ]
+                },
+                "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
+                "checkboxFields": true,
+                "step_variables": {
+                    "incompleteTask": "{{vars.steps.Get_All_Incomplete_Task[0][\"tasks\"] | json_query(\"[?status != '\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed']\")}}"
+                }
+            },
+            "status": null,
+            "top": "165",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "6f263d5c-06e0-47ff-8a3e-99867c8ad347"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Incomplete Task Comment",
+            "description": "Mark Asset Change Activity record as Close and add incomplete task comment",
+            "arguments": {
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<h3>Closure Note<\/h3>\n<h6>Record get closed with following pending tasks:<\/h6>\n<p>{% for data in vars.incompleteTask %}<\/p>\n<ul>\n<li><a href=\"\/modules\/tasks\/{{data['@id'].split('\/')[-1]}}\" target=\"_blank\" rel=\"noopener\">{{data['name']}}<\/a><\/li>\n<\/ul>\n<p>{% endfor %}<\/p>",
+                    "records": ""
+                },
+                "resource": {
+                    "closedOn": "{{arrow.utcnow().int_timestamp}}"
+                },
+                "_showJson": false,
+                "operation": "Append",
+                "collection": "{{vars.input.records[0]['@id']}}",
+                "__recommend": [],
+                "collectionType": "\/api\/3\/asset_change_activities",
+                "fieldOperation": {
+                    "recordTags": "Append"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "435",
+            "left": "650",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
+            "group": null,
+            "uuid": "94da0c6a-52b0-4928-8e51-06a50de8968a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is Incomplete Task Exists",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/94da0c6a-52b0-4928-8e51-06a50de8968a",
+                        "condition": "{{ vars.incompleteTask | length > 0 }}",
+                        "step_name": "Incomplete Task Comment"
+                    },
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/5c7ff996-4f2e-4865-906f-173b691fc4eb",
+                        "step_name": "Update Asset Change Activity"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "110145ac-6461-473f-b3c5-d82ab529d4ce"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Start",
             "description": null,
             "arguments": {
@@ -63,7 +159,7 @@
             },
             "status": null,
             "top": "30",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/9300bf69-5063-486d-b3a6-47eb9da24872",
             "group": null,
             "uuid": "f6e602b6-109f-4bd8-bf3f-28ce08117592"
@@ -87,8 +183,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "165",
-            "left": "125",
+            "top": "435",
+            "left": "300",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "5c7ff996-4f2e-4865-906f-173b691fc4eb"
@@ -97,13 +193,43 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Update Asset Change Activity",
+            "name": "Get All Incomplete Task -> Is Incomplete Task Exists",
+            "targetStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
+            "sourceStep": "\/api\/3\/workflow_steps\/6f263d5c-06e0-47ff-8a3e-99867c8ad347",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "befccc10-e4fc-4725-8950-d6719061559c"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Incomplete Task Exists -> Copy of Update Asset Change Activity",
+            "targetStep": "\/api\/3\/workflow_steps\/94da0c6a-52b0-4928-8e51-06a50de8968a",
+            "sourceStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "02ce666f-b7ba-40c8-9b63-984a3ec07b9d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is Incomplete Task Exists -> Update Asset Change Activity",
             "targetStep": "\/api\/3\/workflow_steps\/5c7ff996-4f2e-4865-906f-173b691fc4eb",
+            "sourceStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "707bf21d-41a6-4216-b84d-e9d7ec6a35b7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Get All Open Task",
+            "targetStep": "\/api\/3\/workflow_steps\/6f263d5c-06e0-47ff-8a3e-99867c8ad347",
             "sourceStep": "\/api\/3\/workflow_steps\/f6e602b6-109f-4bd8-bf3f-28ce08117592",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "db14f7ef-27d1-457d-a0c8-13a23f577740"
+            "uuid": "819d525b-32af-43fb-b1b2-629853c48f49"
         }
     ],
     "groups": [],

--- a/playbooks/02 - Use Case - Asset Change Activity/Manage Asset Change Activity Closure.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Manage Asset Change Activity Closure.json
@@ -17,7 +17,7 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Get All Incomplete Task",
+            "name": "Get All Incomplete Tasks",
             "description": null,
             "arguments": {
                 "query": {
@@ -40,7 +40,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "incompleteTask": "{{vars.steps.Get_All_Incomplete_Task[0][\"tasks\"] | json_query(\"[?status != '\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed']\")}}"
+                    "incompleteTask": "{{vars.steps.Get_All_Incomplete_Tasks[0][\"tasks\"] | json_query(\"[?status != '\/api\/3\/picklists\/343f4b67-e929-4205-bf95-ba5b70545fed']\")}}"
                 }
             },
             "status": null,
@@ -53,7 +53,7 @@
         {
             "@type": "WorkflowStep",
             "name": "Incomplete Task Comment",
-            "description": "Mark Asset Change Activity record as Close and add incomplete task comment",
+            "description": null,
             "arguments": {
                 "message": {
                     "tags": [],
@@ -85,7 +85,7 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Is Incomplete Task Exists",
+            "name": "Is Incomplete Tasks Exists",
             "description": null,
             "arguments": {
                 "conditions": [
@@ -193,7 +193,7 @@
     "routes": [
         {
             "@type": "WorkflowRoute",
-            "name": "Get All Incomplete Task -> Is Incomplete Task Exists",
+            "name": "Get All Incomplete Task -> Incomplete Tasks Exists",
             "targetStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
             "sourceStep": "\/api\/3\/workflow_steps\/6f263d5c-06e0-47ff-8a3e-99867c8ad347",
             "label": null,
@@ -203,7 +203,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Incomplete Task Exists -> Copy of Update Asset Change Activity",
+            "name": "Incomplete Tasks Exists -> Update Asset Change Activity",
             "targetStep": "\/api\/3\/workflow_steps\/94da0c6a-52b0-4928-8e51-06a50de8968a",
             "sourceStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
             "label": "Yes",
@@ -213,7 +213,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Is Incomplete Task Exists -> Update Asset Change Activity",
+            "name": "Incomplete Tasks Exists -> Update Asset Change Activity",
             "targetStep": "\/api\/3\/workflow_steps\/5c7ff996-4f2e-4865-906f-173b691fc4eb",
             "sourceStep": "\/api\/3\/workflow_steps\/110145ac-6461-473f-b3c5-d82ab529d4ce",
             "label": "No",
@@ -223,7 +223,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> Get All Open Task",
+            "name": "Start -> Get All Open Tasks",
             "targetStep": "\/api\/3\/workflow_steps\/6f263d5c-06e0-47ff-8a3e-99867c8ad347",
             "sourceStep": "\/api\/3\/workflow_steps\/f6e602b6-109f-4bd8-bf3f-28ce08117592",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db"
                 },
@@ -5257,7 +5257,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7"
                 },
@@ -5560,7 +5560,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5596,7 +5596,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5773,7 +5773,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5810,7 +5810,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5847,7 +5847,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -5287,8 +5287,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comments on asset as Approver Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5316,8 +5316,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comments on asset as Assignee Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5345,8 +5345,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comments on asset as Identify Security Control task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5374,8 +5374,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comments on asset as Implement Change task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5403,8 +5403,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comments on asset as Update Baseline task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5432,8 +5432,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comments on asset as Verify Security Controls task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5461,8 +5461,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comments on asset as Verify Software Source task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5889,7 +5889,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Copy of Comment Assignee Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
             "sourceStep": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510",
             "label": null,
@@ -5909,7 +5909,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Comment Verify Software Source Task Complete",
+            "name": "Assignee Approval To Implement -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
             "sourceStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
             "label": null,
@@ -5929,7 +5929,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510",
             "sourceStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
             "label": "Yes",
@@ -5939,7 +5939,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "sourceStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
             "label": null,
@@ -5949,7 +5949,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
             "sourceStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
             "label": null,
@@ -5959,7 +5959,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
             "sourceStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
             "label": null,
@@ -5969,7 +5969,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
             "sourceStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
             "label": null,
@@ -5979,7 +5979,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Check Approver 2 -> Implement Change",
+            "name": "Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "sourceStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
             "label": "No",
@@ -5989,7 +5989,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Comment Approver Approval To Implement Task Complete -> Update Baseline",
+            "name": "Approver Approval To Implement Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
             "sourceStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
             "label": null,
@@ -5999,7 +5999,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Comment Approver Approval To Implement Task Complete -> Verify Security Controls",
+            "name": "Approver Approval To Implement Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
             "sourceStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
             "label": null,
@@ -6009,7 +6009,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Comment Verify Security Controls Task Complete -> Mark Activity Closed",
+            "name": "Verify Security Controls Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/d2f8b90d-6773-4e7d-ac41-2ee63eb20d84",
             "sourceStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
             "label": null,
@@ -6029,7 +6029,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
             "sourceStep": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537",
             "label": null,
@@ -6039,7 +6039,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Copy of Comment Approver Approval To Implement Task Complete",
+            "name": "Implement Change -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
             "sourceStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "label": null,
@@ -6059,7 +6059,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Copy of Comment Verify Security Controls Task Complete",
+            "name": "Update Baseline -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
             "sourceStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
             "label": null,
@@ -6069,7 +6069,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Copy of Comment Approver Approval To Implement Task Complete",
+            "name": "Verify Security Controls -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
             "sourceStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
             "label": null,
@@ -6079,7 +6079,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Copy of Comment Identify Security Control Task Complete",
+            "name": "Verify Software Source -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
             "sourceStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db"
                 },
@@ -5257,7 +5257,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7"
                 },
@@ -5560,7 +5560,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5596,7 +5596,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5773,7 +5773,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5810,7 +5810,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5847,7 +5847,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1120",
-            "left": "480",
+            "top": "1515",
+            "left": "383",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "ae490276-c33a-4735-80b5-0c834c27f510"
@@ -5257,7 +5257,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7"
                 },
@@ -5279,11 +5279,214 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
-            "left": "125",
+            "top": "1110",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "94327c0d-46c0-4ce6-ad78-729c4247d9db"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1650",
+            "left": "383",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "136ddcd8-b68a-47a2-afd2-a46d7b150c71"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "68e94c3a-8f0e-4657-9d45-fdc23e2ac78a"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "e469e875-98a0-4b98-b2b4-5b94fe1efb73"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "c0424398-02e9-487e-b890-7afab8a0e2d8"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2460",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "e70c0639-9b7e-4727-96df-8cf5e9961da6"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "ea355595-c7a3-43c0-95ca-445ffa21d362"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "6d3d4d09-af6d-49e3-85e8-aac946167c09"
         },
         {
             "@type": "WorkflowStep",
@@ -5291,7 +5494,15 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5299,7 +5510,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "475",
+            "left": "125",
             "stepType": "\/api\/3\/workflow_step_types\/0109f35d-090b-4a2b-bd8a-94cbc3508562",
             "group": null,
             "uuid": "f6fc3f3d-fa02-4943-9c66-0e50cc903a75"
@@ -5329,7 +5540,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -5348,7 +5560,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5370,7 +5582,7 @@
             },
             "status": null,
             "top": "570",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "b10fe055-8cc1-4163-a11b-5f87a6c9c537"
@@ -5384,7 +5596,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5406,8 +5618,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
-            "left": "125",
+            "top": "1785",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "683afbc0-4503-4bcf-ba8b-0c925bc9ff6d"
@@ -5433,8 +5645,8 @@
                 ]
             },
             "status": null,
-            "top": "975",
-            "left": "125",
+            "top": "1380",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
             "uuid": "a57ed38c-696c-4bc9-8ad5-e1e0f66bced2"
@@ -5458,7 +5670,7 @@
             },
             "status": null,
             "top": "435",
-            "left": "125",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "3dad4662-b4f5-4438-96ce-94314ff8d22e"
@@ -5482,8 +5694,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
-            "left": "125",
+            "top": "2595",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
             "uuid": "d2f8b90d-6773-4e7d-ac41-2ee63eb20d84"
@@ -5561,7 +5773,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5583,8 +5795,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
-            "left": "125",
+            "top": "2325",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8"
@@ -5598,7 +5810,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510"
                 },
@@ -5620,8 +5832,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
-            "left": "125",
+            "top": "2055",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "97ca00d9-53d4-4e6c-ba61-d30857d46f48"
@@ -5635,7 +5847,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537"
                 },
@@ -5657,8 +5869,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
-            "left": "125",
+            "top": "840",
+            "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "b4748646-0208-45c2-a1d5-26d7a5e0edc7"
@@ -5677,13 +5889,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
+            "name": "Approver Approval To Implement -> Copy of Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
             "sourceStep": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "f6430490-587a-423a-a88b-ed7e7a8dc0f9"
+            "uuid": "6823d97b-9165-41e1-b4ff-a9004b38b7c7"
         },
         {
             "@type": "WorkflowRoute",
@@ -5697,63 +5909,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
+            "name": "Assignee Approval To Implement -> Copy of Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
             "sourceStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "997bd10b-5b3f-491c-84ae-df5541564168"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
-            "sourceStep": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "36448457-589e-450c-b18b-ada2600cdc9e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
-            "sourceStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "242d0551-9e31-409f-ae76-27b939b8123a"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/d2f8b90d-6773-4e7d-ac41-2ee63eb20d84",
-            "sourceStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "e54c268a-06a4-4dd2-b0d6-7b20c1061993"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
-            "sourceStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "f26f428b-d379-4e96-bad3-2ea04f3f3a9e"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Software Source -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
-            "sourceStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "62d43b6c-88e9-4925-9aae-166401af2cc0"
+            "uuid": "790da6c8-cdbc-4d2f-97d3-060cda15ecce"
         },
         {
             "@type": "WorkflowRoute",
@@ -5777,6 +5939,46 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
+            "sourceStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "701641d0-0a90-4d1b-a858-be9fa49af9d6"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
+            "sourceStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "612d50d0-8082-4c8b-80d4-ae1ba7e6f9c3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
+            "sourceStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "25a897f2-9f92-4848-ba18-03c71cec3781"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
+            "sourceStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2c7a071e-6a23-41bb-940e-c78ff0f90bcc"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy of Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "sourceStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
@@ -5784,6 +5986,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "0ecefa1b-9409-48ea-9704-48fd52eaf73e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Copy of Comment Approver Approval To Implement Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
+            "sourceStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d872e778-c6a6-46fd-a6b6-96d64d93ac8d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Copy of Comment Approver Approval To Implement Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
+            "sourceStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "840acadb-c09e-4dba-bdd7-15fe3309a5de"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Copy of Comment Verify Security Controls Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/d2f8b90d-6773-4e7d-ac41-2ee63eb20d84",
+            "sourceStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5b892803-76db-42fb-824d-e759717c309b"
         },
         {
             "@type": "WorkflowRoute",
@@ -5797,6 +6029,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
+            "sourceStep": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2aa54114-d25c-4bdc-8e6b-a54f51d4c5bb"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Copy of Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
+            "sourceStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "2d495b3a-befd-4697-9362-a6c40286f152"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Get Correlated Asset",
             "targetStep": "\/api\/3\/workflow_steps\/8831d564-5ab7-449e-881e-179e5ee2c12f",
             "sourceStep": "\/api\/3\/workflow_steps\/13e059cc-246a-48b5-bf79-58c646e6d350",
@@ -5804,6 +6056,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "6da292b3-1215-4d51-8903-8346e683dfe4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Baseline -> Copy of Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
+            "sourceStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ec00ca66-cf3e-4f6d-88c2-2f6fca200b67"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Copy of Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
+            "sourceStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b6711b49-788c-4445-840a-646eb7f514f7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Copy of Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
+            "sourceStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "cd28f91e-4dc8-4086-be77-3c07039d4a00"
         }
     ],
     "groups": [],
@@ -5813,9 +6095,9 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "ManualTrigger",
         "Asset Change Activity",
-        "Medium Impact Baseline Change",
-        "IT OT"
+        "IT OT",
+        "ManualTrigger",
+        "Medium Impact Baseline Change"
     ]
 }

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -5287,8 +5287,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comments on asset as Approver Approval To Implement task completed",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5316,8 +5316,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comments on asset as Assignee Approval To Implement task completed",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5345,8 +5345,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comments on asset as Identify Security Control task completed",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5374,8 +5374,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comments on asset as Implement Change task completed",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5403,8 +5403,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comments on asset as Update Baseline task completed",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5432,8 +5432,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comments on asset as Verify Security Controls task completed",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5461,8 +5461,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comments on asset as Verify Software Source task completed",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5889,7 +5889,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
             "sourceStep": "\/api\/3\/workflow_steps\/ae490276-c33a-4735-80b5-0c834c27f510",
             "label": null,
@@ -5909,7 +5909,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Verify Software Source Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
             "sourceStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
             "label": null,
@@ -5939,7 +5939,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "sourceStep": "\/api\/3\/workflow_steps\/136ddcd8-b68a-47a2-afd2-a46d7b150c71",
             "label": null,
@@ -5949,7 +5949,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/a57ed38c-696c-4bc9-8ad5-e1e0f66bced2",
             "sourceStep": "\/api\/3\/workflow_steps\/68e94c3a-8f0e-4657-9d45-fdc23e2ac78a",
             "label": null,
@@ -5959,7 +5959,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
             "sourceStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
             "label": null,
@@ -5969,7 +5969,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/94327c0d-46c0-4ce6-ad78-729c4247d9db",
             "sourceStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
             "label": null,
@@ -5989,7 +5989,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Update Baseline",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
             "sourceStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
             "label": null,
@@ -5999,7 +5999,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
             "sourceStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
             "label": null,
@@ -6009,7 +6009,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/d2f8b90d-6773-4e7d-ac41-2ee63eb20d84",
             "sourceStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
             "label": null,
@@ -6029,7 +6029,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e469e875-98a0-4b98-b2b4-5b94fe1efb73",
             "sourceStep": "\/api\/3\/workflow_steps\/b10fe055-8cc1-4163-a11b-5f87a6c9c537",
             "label": null,
@@ -6039,7 +6039,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Approver Approval To Implement Task Complete",
+            "name": "Implement Change -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/c0424398-02e9-487e-b890-7afab8a0e2d8",
             "sourceStep": "\/api\/3\/workflow_steps\/683afbc0-4503-4bcf-ba8b-0c925bc9ff6d",
             "label": null,
@@ -6059,7 +6059,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Verify Security Controls Task Complete",
+            "name": "Update Baseline -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e70c0639-9b7e-4727-96df-8cf5e9961da6",
             "sourceStep": "\/api\/3\/workflow_steps\/0067b73f-e6e2-4a31-80ac-8c2e8d4f80d8",
             "label": null,
@@ -6069,7 +6069,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Approver Approval To Implement Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ea355595-c7a3-43c0-95ca-445ffa21d362",
             "sourceStep": "\/api\/3\/workflow_steps\/97ca00d9-53d4-4e6c-ba61-d30857d46f48",
             "label": null,
@@ -6079,7 +6079,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Identify Security Control Task Complete",
+            "name": "Verify Software Source -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6d3d4d09-af6d-49e3-85e8-aac946167c09",
             "sourceStep": "\/api\/3\/workflow_steps\/b4748646-0208-45c2-a1d5-26d7a5e0edc7",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comments on asset as Approver Approval To Implement task completed",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comments on asset as Assignee Approval To Implement task completed",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comments on asset as Identify Security Control task completed",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comments on asset as Implement Change task completed",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comments on asset as Update Baseline task completed",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comments on asset as Verify Security Controls task completed",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comments on asset as Verify Software Source task completed",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
             "sourceStep": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
             "sourceStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
             "label": null,
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "sourceStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
             "sourceStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
             "sourceStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
             "sourceStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/efd08db9-8413-4529-bfa8-91b055e88cb2",
             "sourceStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
             "sourceStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
             "sourceStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
             "label": null,
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
             "sourceStep": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Implement Change Task Complete",
+            "name": "Implement Change -> Insert Comment Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
             "sourceStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Update Baseline Task Complete",
+            "name": "Update Baseline -> Insert Comment Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
             "sourceStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
             "sourceStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
             "sourceStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comments on asset as Approver Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comments on asset as Assignee Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comments on asset as Identify Security Control task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comments on asset as Implement Change task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comments on asset as Update Baseline task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comments on asset as Verify Security Controls task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comments on asset as Verify Software Source task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
             "sourceStep": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
             "sourceStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
             "label": null,
@@ -5942,7 +5942,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393",
             "sourceStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
             "label": "Yes",
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "sourceStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
             "sourceStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
             "sourceStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "name": "Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
             "sourceStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/efd08db9-8413-4529-bfa8-91b055e88cb2",
             "sourceStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
             "sourceStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
             "sourceStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
             "label": null,
@@ -6022,7 +6022,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Check Approver 2 -> Implement Change",
+            "name": "Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "sourceStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
             "label": "No",
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
             "sourceStep": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "name": "Implement Change -> Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
             "sourceStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "name": "Update Baseline -> Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
             "sourceStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
             "sourceStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
             "sourceStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "568",
+            "top": "1520",
+            "left": "780",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "ef3f0c06-21cf-45d3-9521-ec5f3f980393"
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f"
                 },
@@ -5291,7 +5291,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5299,11 +5299,222 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1640",
+            "left": "780",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "5a7c6b0b-d162-4b64-b439-82b5b8b0948d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "027b90cb-912e-4bc1-aa73-54df96c66455"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "83e0f883-820d-4509-bb14-fed4957c3697"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "ccb30383-e7f4-43ea-96d3-29a21a32e345"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2460",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "a526f2d2-e7c3-4f19-a1ef-385aaef55294"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "517b9df1-95d6-44e3-a166-9a422a5459f1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "e67a1b0c-a1f8-4714-9c91-f8f60d79f065"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Do Nothing",
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5341,7 +5552,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -5360,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5396,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5418,7 +5630,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1785",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5445,7 +5657,7 @@
                 ]
             },
             "status": null,
-            "top": "975",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -5470,7 +5682,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
+            "top": "2595",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -5574,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5596,7 +5808,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "2325",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5611,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393"
                 },
@@ -5633,7 +5845,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "2055",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5648,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b"
                 },
@@ -5670,7 +5882,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5690,13 +5902,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
+            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
             "sourceStep": "\/api\/3\/workflow_steps\/ef3f0c06-21cf-45d3-9521-ec5f3f980393",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "885b9838-b398-4962-b612-424100b84123"
+            "uuid": "aa02ef34-1771-40cf-bd11-9005bed84b95"
         },
         {
             "@type": "WorkflowRoute",
@@ -5710,63 +5922,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
+            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
             "sourceStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "e50d77cf-b170-4a37-aa55-c16dea422c2f"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
-            "sourceStep": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "e9c60d3b-785f-4bf2-bc03-ba773264639c"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
-            "sourceStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "fbfe49ca-b41d-4038-b7da-2e8e1c450538"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/efd08db9-8413-4529-bfa8-91b055e88cb2",
-            "sourceStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "da4f23af-7f90-41c0-a98a-8c3b3e7be364"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
-            "sourceStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "8641ac9c-9c23-4936-aa7e-01ff95dffb03"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Software Source -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
-            "sourceStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "a3d78018-ac67-4a8e-96ca-9b9d65571fa0"
+            "uuid": "bd7a4918-c027-4cb6-bd47-951033dca8bc"
         },
         {
             "@type": "WorkflowRoute",
@@ -5790,6 +5952,76 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
+            "sourceStep": "\/api\/3\/workflow_steps\/5a7c6b0b-d162-4b64-b439-82b5b8b0948d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "448e5ff7-b548-489f-b7ce-0913765bc637"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
+            "sourceStep": "\/api\/3\/workflow_steps\/027b90cb-912e-4bc1-aa73-54df96c66455",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d6e0c64e-a4ed-4ad2-83ee-670be8944847"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
+            "sourceStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9543a31d-f64e-4feb-b409-146c91a8f3ce"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
+            "sourceStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "97274154-2ca2-4767-b2dc-542ac0eb4fad"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/efd08db9-8413-4529-bfa8-91b055e88cb2",
+            "sourceStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "59d759c9-5287-4b2b-ab0e-7a94e341fc4e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
+            "sourceStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "abe6942c-2e13-4c49-a718-87160e0fded8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/d279c83f-1db0-44b5-870a-058e69dfc38e",
+            "sourceStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "69b103ff-22ac-4f13-891b-f7280e32683c"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy of Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
             "sourceStep": "\/api\/3\/workflow_steps\/6b1d8d32-4647-4a1a-ba0f-cdb5d58f0c44",
@@ -5810,6 +6042,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/83e0f883-820d-4509-bb14-fed4957c3697",
+            "sourceStep": "\/api\/3\/workflow_steps\/31791554-8cdf-4301-a38d-9dc4bc85b31b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0d71849f-eea9-4920-ae75-0028986362c4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/ccb30383-e7f4-43ea-96d3-29a21a32e345",
+            "sourceStep": "\/api\/3\/workflow_steps\/d0e1617e-e85f-4da6-962d-a153e07c3785",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "a5fed18a-14f0-4a3f-9fbc-ad47fe2cbed8"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Get Correlated Asset",
             "targetStep": "\/api\/3\/workflow_steps\/70251655-60c5-496e-ae6d-26ccab635174",
             "sourceStep": "\/api\/3\/workflow_steps\/afe2d238-7467-4733-a8cf-d19f4f81750b",
@@ -5817,6 +6069,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "23e8fa4c-04da-4379-917b-dc9c0b8ee7e3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/a526f2d2-e7c3-4f19-a1ef-385aaef55294",
+            "sourceStep": "\/api\/3\/workflow_steps\/dd1a6a85-2359-4bfe-9f16-2974ec890b7c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "72476f1a-6990-4baa-a823-1a64cebf6729"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/517b9df1-95d6-44e3-a166-9a422a5459f1",
+            "sourceStep": "\/api\/3\/workflow_steps\/2bd8cd16-d054-4ef0-9391-320cefc0138b",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "5f5a707e-94d4-42cb-aee0-89e27d02c217"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/e67a1b0c-a1f8-4714-9c91-f8f60d79f065",
+            "sourceStep": "\/api\/3\/workflow_steps\/e5e0c8ad-8ac3-4673-b0f5-5866142b689f",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "297cf92a-d7e6-402a-bdbe-fb5f6de5e9c2"
         }
     ],
     "groups": [],
@@ -5826,9 +6108,9 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "ManualTrigger",
         "Asset Change Activity",
-        "Modify Cyber Asset",
-        "IT OT"
+        "IT OT",
+        "ManualTrigger",
+        "Modify Cyber Asset"
     ]
 }

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b"
                 },
@@ -46,7 +46,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1100",
+            "top": "1500",
             "left": "760",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805"
                 },
@@ -5291,7 +5291,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5299,11 +5299,222 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1620",
+            "left": "760",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "155aacd3-84ac-4b00-b958-e28e6d4ca1b9"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "d19d2829-57c7-49b7-a55b-710d0e8490bd"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "4fb8c778-5719-4084-bf91-175c81290618"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "780b69b4-721d-40bf-a20b-3afae0dae535"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2460",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "4ce1e5f9-5be2-45c2-85d8-7c394519c759"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "00b131be-8dae-46a6-8a8d-eeddea51128e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "6c2fcab0-0e5d-4324-a924-10a13bb62998"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Do Nothing",
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5341,7 +5552,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -5360,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5396,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5418,7 +5630,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1785",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5445,7 +5657,7 @@
                 ]
             },
             "status": null,
-            "top": "975",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -5470,7 +5682,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
+            "top": "2595",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -5574,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5596,7 +5808,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "2325",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5611,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5633,7 +5845,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "2055",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5648,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d"
                 },
@@ -5670,7 +5882,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5690,13 +5902,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
+            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
             "sourceStep": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "0f398d4e-e3e6-4bc5-a32a-8cb9594a4e50"
+            "uuid": "b55e6c13-7772-4f69-a4ba-6e68e1cc0270"
         },
         {
             "@type": "WorkflowRoute",
@@ -5710,63 +5922,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
+            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
             "sourceStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "346fbac7-e600-4588-8915-50ab47708500"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
-            "sourceStep": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "90c4c678-4523-46d9-9526-92aa85747731"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
-            "sourceStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "90f243ce-dbfe-4c72-87d3-0a1847436fce"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/aeb66e1f-699f-46d8-bd13-857930a9ee39",
-            "sourceStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "526eb782-01d3-4902-a80c-db94d80b837a"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
-            "sourceStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "9d4f8620-bd93-4284-a851-cd309a30bcf9"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Software Source -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
-            "sourceStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "14cad8ed-8839-4247-96e3-e2613414dd3c"
+            "uuid": "ff65fd38-1cb4-46e6-abe8-39c8434fbf8c"
         },
         {
             "@type": "WorkflowRoute",
@@ -5790,6 +5952,76 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
+            "sourceStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "440235f0-907f-4a41-bd71-e60fbae0ed13"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
+            "sourceStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "41852861-6476-4690-b9ec-57acd0f1e5d4"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
+            "sourceStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f63f0c76-8c18-421c-96bb-6da128f93f29"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
+            "sourceStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "451f63ea-9725-4266-b0a1-f9546306b803"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/aeb66e1f-699f-46d8-bd13-857930a9ee39",
+            "sourceStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "0d997457-4441-4459-a191-8cff3183e43e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
+            "sourceStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "b0d27c19-6037-486d-b148-cd0c933b7da8"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
+            "sourceStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "297fee6e-53ea-41a9-bfa2-07d8225a4160"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy of Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "sourceStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
@@ -5810,6 +6042,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
+            "sourceStep": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6b39e0c6-5bb5-4afb-96aa-6d5690a5fb65"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
+            "sourceStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d11e846e-1f21-49be-84e7-5b72a0fea99c"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Get Correlated Asset",
             "targetStep": "\/api\/3\/workflow_steps\/89f1e418-aeab-430c-a22e-604575727e73",
             "sourceStep": "\/api\/3\/workflow_steps\/f79c7417-3e70-483f-b0e0-9810372500b3",
@@ -5817,6 +6069,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "0dd4734d-8a2e-4a7c-b525-dceaa13830c7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
+            "sourceStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "3423c80f-766a-4899-a6fd-de45c291d43d"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
+            "sourceStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "53c3b598-f007-4ebc-9ecc-50e5a3d2680e"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
+            "sourceStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "c359c1d2-c794-4282-a432-01621251db69"
         }
     ],
     "groups": [],
@@ -5826,9 +6108,9 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "ManualTrigger",
         "Asset Change Activity",
-        "Remove Cyber Asset",
-        "IT OT"
+        "IT OT",
+        "ManualTrigger",
+        "Remove Cyber Asset"
     ]
 }

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comments on asset as Approver Approval To Implement task completed",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comments on asset as Assignee Approval To Implement task completed",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comments on asset as Identify Security Control task completed",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comments on asset as Implement Change task completed",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comments on asset as Update Baseline task completed",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comments on asset as Verify Security Controls task completed",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comments on asset as Verify Software Source task completed",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
             "sourceStep": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
             "sourceStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
             "label": null,
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "sourceStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
             "sourceStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
             "sourceStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
             "sourceStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/aeb66e1f-699f-46d8-bd13-857930a9ee39",
             "sourceStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
             "sourceStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
             "sourceStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
             "label": null,
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
             "sourceStep": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Implement Change Task Complete",
+            "name": "Implement Change -> Insert Comment Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
             "sourceStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Update Baseline Task Complete",
+            "name": "Update Baseline -> Insert Comment Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
             "sourceStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
             "sourceStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
             "sourceStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comments on asset as Approver Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comments on asset as Assignee Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comments on asset as Identify Security Control task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comments on asset as Implement Change task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comments on asset as Update Baseline task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comments on asset as Verify Security Controls task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comments on asset as Verify Software Source task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
             "sourceStep": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
             "sourceStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
             "label": null,
@@ -5942,7 +5942,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a",
             "sourceStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
             "label": "Yes",
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "sourceStep": "\/api\/3\/workflow_steps\/155aacd3-84ac-4b00-b958-e28e6d4ca1b9",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
             "sourceStep": "\/api\/3\/workflow_steps\/d19d2829-57c7-49b7-a55b-710d0e8490bd",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
             "sourceStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "name": "Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
             "sourceStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/aeb66e1f-699f-46d8-bd13-857930a9ee39",
             "sourceStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
             "sourceStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b",
             "sourceStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
             "label": null,
@@ -6022,7 +6022,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Check Approver 2 -> Implement Change",
+            "name": "Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "sourceStep": "\/api\/3\/workflow_steps\/0680ad0f-1823-4400-9ce2-3d216f124e16",
             "label": "No",
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4fb8c778-5719-4084-bf91-175c81290618",
             "sourceStep": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "name": "Implement Change -> Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/780b69b4-721d-40bf-a20b-3afae0dae535",
             "sourceStep": "\/api\/3\/workflow_steps\/3958659c-7c7a-45ef-9762-4818be1ceda8",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "name": "Update Baseline -> Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/4ce1e5f9-5be2-45c2-85d8-7c394519c759",
             "sourceStep": "\/api\/3\/workflow_steps\/2930a54a-5291-4263-a5a4-125b1fa0e837",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/00b131be-8dae-46a6-8a8d-eeddea51128e",
             "sourceStep": "\/api\/3\/workflow_steps\/fabf2a1d-2a74-4a03-a10b-848f1d701383",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/6c2fcab0-0e5d-4324-a924-10a13bb62998",
             "sourceStep": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/47077313-fbf4-4ac5-b96a-85eb4bc8de0b"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/56c9c6c1-b130-46b5-90fb-19dcd9ac2805"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/02cfd3b6-6a50-4a95-bd15-91bc27982d3a"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/06fdcc05-be6b-4de0-83b3-c84715997e2d"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Approver Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1110",
-            "left": "568",
+            "top": "1520",
+            "left": "840",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "6c197eae-ca1d-4bb1-a827-74eb15544350"
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Assignee Approval To Implement - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a"
                 },
@@ -5291,7 +5291,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "840",
+            "top": "1110",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5299,11 +5299,222 @@
         },
         {
             "@type": "WorkflowStep",
+            "name": "Comment Approver Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1640",
+            "left": "840",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "1d429dec-82c1-4c70-876c-f3d85673fb03"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Assignee Approval To Implement Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1245",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "d3b805d0-19ec-4366-bdca-c7e97cde6eb1"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Identify Security Control Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "705",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "38b23a3c-cdff-446f-ac5a-3a65bbf6fb57"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Implement Change Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "1920",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "514c0107-2375-44db-b504-6f6f1363f22e"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Update Baseline Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2460",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "c6a0e667-a8c5-46d4-998d-911fddcbe125"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Security Controls Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "2190",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "e7b2c68e-0b25-439d-9076-861bd3e6baec"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Comment Verify Software Source Task Complete",
+            "description": null,
+            "arguments": {
+                "resource": {
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "assets": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "people": [],
+                    "content": "<p>Task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source['task_data'].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source['task_data'].name}}<\/a> completed for <strong>'Asset Change Activity' <a href=\"\/modules\/asset_change_activities\/{{vars.input.records[0].uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/strong><\/p>",
+                    "__replace": "",
+                    "isImportant": false,
+                    "peopleUpdated": false
+                },
+                "operation": "Overwrite",
+                "collection": "\/api\/3\/comments",
+                "__recommend": [],
+                "fieldOperation": {
+                    "recordTags": "Overwrite"
+                },
+                "step_variables": []
+            },
+            "status": null,
+            "top": "975",
+            "left": "475",
+            "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
+            "group": null,
+            "uuid": "fca39afc-527d-4b42-8106-5affd522c9d6"
+        },
+        {
+            "@type": "WorkflowStep",
             "name": "Do Nothing",
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.1",
+                "version": "3.2.4",
+                "message": {
+                    "tags": [],
+                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
+                    "tenant": "",
+                    "thread": false,
+                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
+                    "records": "{{vars.input.records[0]['@id']}}"
+                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5341,7 +5552,8 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
+                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
                 }
             },
             "status": null,
@@ -5360,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Identify Security Control - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5396,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Implement Change - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5418,7 +5630,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1245",
+            "top": "1785",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5445,7 +5657,7 @@
                 ]
             },
             "status": null,
-            "top": "975",
+            "top": "1380",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
             "group": null,
@@ -5470,7 +5682,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1650",
+            "top": "2595",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928722",
             "group": null,
@@ -5574,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Update Baseline - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5596,7 +5808,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1515",
+            "top": "2325",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5611,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span class=\"badge badge-pill badge-danger\" style=\"background: green; color: #fff;\">Verify Security Controls - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5633,7 +5845,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1380",
+            "top": "2055",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5648,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task <span style=\"background: green; color: #fff;\" class=\"badge badge-pill badge-danger\">Verify Software Source - {{vars.input.records[0].title}}<\/span><\/p>",
+                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c"
                 },
@@ -5670,7 +5882,7 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "705",
+            "top": "840",
             "left": "475",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
@@ -5690,13 +5902,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Implement Change",
-            "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
+            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
             "sourceStep": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "38e12812-06db-442a-8c2f-bcbef4a697ee"
+            "uuid": "62067366-e9dc-4127-ad04-3c1724a6db22"
         },
         {
             "@type": "WorkflowRoute",
@@ -5710,63 +5922,13 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Copy of Check Approver 2",
-            "targetStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
+            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
             "sourceStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "da60b66f-1f5b-4967-854b-5eeb693f3f38"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Identify Security Control -> Assignee Verify Software Source",
-            "targetStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
-            "sourceStep": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "dfa94d86-80b9-4865-be7b-ad7cc6cd32fa"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Implement Change -> Assignee Verify Security Controls",
-            "targetStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
-            "sourceStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "63bb5fcf-5328-4ed9-8290-79176959497b"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Update Baseline -> Activity Completed",
-            "targetStep": "\/api\/3\/workflow_steps\/263e0483-6dc0-478d-94d0-11444ac888ec",
-            "sourceStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "7d63996d-207a-4245-88f4-d54cf341a5f3"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Security Controls -> Assignee Update Baseline",
-            "targetStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
-            "sourceStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "911e70f6-d8cd-48e9-9418-4d35cd2e01bb"
-        },
-        {
-            "@type": "WorkflowRoute",
-            "name": "Assignee Verify Software Source -> Assignee Approval To Implement",
-            "targetStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
-            "sourceStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
-            "label": null,
-            "isExecuted": false,
-            "group": null,
-            "uuid": "1945a1d3-9f67-4fb6-8187-d285687fff87"
+            "uuid": "ea61f921-766e-4e87-b1ca-a9df1a1cb355"
         },
         {
             "@type": "WorkflowRoute",
@@ -5790,6 +5952,76 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
+            "sourceStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "9580eb0f-821a-4e22-ab1d-399bf85b2d45"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "targetStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
+            "sourceStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ce3c8781-86ae-4b20-ad8d-1656e41b0d84"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "targetStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
+            "sourceStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "74d07b47-1aaa-4b9c-93da-a4b1c8b66649"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "targetStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
+            "sourceStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "f350962f-caf7-4208-957f-3bcd5fac4ff5"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "targetStep": "\/api\/3\/workflow_steps\/263e0483-6dc0-478d-94d0-11444ac888ec",
+            "sourceStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "02418df8-4d1a-427a-8cf9-c86459dd08b3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "targetStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
+            "sourceStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "02d9aa96-d628-4635-8fa4-84eb32523ac7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "targetStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
+            "sourceStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "4e238bfa-03cd-4f44-ab87-cc0b1d5755c0"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Copy of Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "sourceStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
@@ -5810,6 +6042,26 @@
         },
         {
             "@type": "WorkflowRoute",
+            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
+            "sourceStep": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ad48d8eb-f0a0-4a6e-a7a6-2eb1c8eaa6bb"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
+            "sourceStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "aff26195-59e2-42e3-bb95-67e8d0b81d63"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Start -> Get Correlated Asset",
             "targetStep": "\/api\/3\/workflow_steps\/fe230f14-ee3f-4377-9605-4ca8507ecef7",
             "sourceStep": "\/api\/3\/workflow_steps\/8a80265d-1b54-4b22-9da6-db11b8e14fef",
@@ -5817,6 +6069,36 @@
             "isExecuted": false,
             "group": null,
             "uuid": "1930a6fb-56be-4389-9bf7-3d9c89aba0d0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
+            "sourceStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "34692e95-a98f-488a-8329-1edd8e7a4610"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
+            "sourceStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d8809369-1e09-4ff9-b627-d64baa2a53e7"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "targetStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
+            "sourceStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6dea09a0-7e5c-4453-8964-bbb785517126"
         }
     ],
     "groups": [],
@@ -5826,9 +6108,9 @@
     "isPrivate": false,
     "deletedAt": null,
     "recordTags": [
-        "ManualTrigger",
         "Asset Change Activity",
-        "Replace Cyber Asset",
-        "IT OT"
+        "IT OT",
+        "ManualTrigger",
+        "Replace Cyber Asset"
     ]
 }

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Approver Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b"
                 },
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Assignee Approval To Implement'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a"
                 },
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Identify Security Control'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Implement Change'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Update Baseline'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Security Controls'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added Task to <strong>'Verify Software Source'<\/strong> for <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a><\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Approver Approval To Implement Task Complete",
-            "description": null,
+            "name": "Approver Approval To Implement Task Complete",
+            "description": "Comment on assets as Approver Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Assignee Approval To Implement Task Complete",
-            "description": null,
+            "name": "Assignee Approval To Implement Task Complete",
+            "description": "Comment on assets as Assignee Approval To Implement task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Identify Security Control Task Complete",
-            "description": null,
+            "name": "Identify Security Control Task Complete",
+            "description": "Comment on assets as Identify Security Control task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Implement Change Task Complete",
-            "description": null,
+            "name": "Implement Change Task Complete",
+            "description": "Comment on assets as Implement Change task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Update Baseline Task Complete",
-            "description": null,
+            "name": "Update Baseline Task Complete",
+            "description": "Comment on assets as Update Baseline task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Security Controls Task Complete",
-            "description": null,
+            "name": "Verify Security Controls Task Complete",
+            "description": "Comment on assets as Verify Security Controls task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Comment Verify Software Source Task Complete",
-            "description": null,
+            "name": "Verify Software Source Task Complete",
+            "description": "Comment on assets as Verify Software Source task completed",
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Comment Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
             "sourceStep": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Comment Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
             "sourceStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
             "label": null,
@@ -5942,7 +5942,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Check Approver 3 -> Copy of Assignee Approval To Implement",
+            "name": "Check Approver 3 -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350",
             "sourceStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
             "label": "Yes",
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "sourceStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
             "sourceStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
             "sourceStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Implement Change Task Complete -> Verify Security Controls",
+            "name": "Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
             "sourceStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/263e0483-6dc0-478d-94d0-11444ac888ec",
             "sourceStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
             "sourceStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
             "sourceStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
             "label": null,
@@ -6022,7 +6022,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Copy of Check Approver 2 -> Implement Change",
+            "name": "Check Approver 2 -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "sourceStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
             "label": "No",
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Comment Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
             "sourceStep": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Comment Implement Change Task Complete",
+            "name": "Implement Change -> Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
             "sourceStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Comment Update Baseline Task Complete",
+            "name": "Update Baseline -> Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
             "sourceStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Comment Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
             "sourceStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Comment Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
             "sourceStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -24,7 +24,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Approver_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Approver_Approval_To_Implement.name}}<\/a> to <strong>'Approver Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b"
                 },
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1520",
-            "left": "840",
+            "top": "1515",
+            "left": "383",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "6c197eae-ca1d-4bb1-a827-74eb15544350"
@@ -5269,7 +5269,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Assignee_Approval_To_Implement.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Assignee_Approval_To_Implement.name}}<\/a> to <strong>'Assignee Approval To Implement'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a"
                 },
@@ -5320,8 +5320,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1640",
-            "left": "840",
+            "top": "1650",
+            "left": "383",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
             "uuid": "1d429dec-82c1-4c70-876c-f3d85673fb03"
@@ -5506,7 +5506,6 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "version": "3.2.4",
                 "message": {
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5515,6 +5514,7 @@
                     "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
+                "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5572,7 +5572,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Identify Security Control'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Identify_Security_Control.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Identify_Security_Control.name}}<\/a> to <strong>'Identify Security Control'<\/strong><\/p>",
                     "records": "{{vars.input.records[0]['@id']}}"
                 },
                 "resource": {
@@ -5608,7 +5608,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Implement_Change.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Implement_Change.name}}<\/a> to <strong>'Implement Change'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5786,7 +5786,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Update_Baseline.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Update_Baseline.name}}<\/a> to <strong>'Update Baseline'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5823,7 +5823,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Security_Controls.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Security_Controls.name}}<\/a> to <strong>'Verify Security Controls'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350"
                 },
@@ -5860,7 +5860,7 @@
                     "tags": [],
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
                     "tenant": "",
-                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.input.records[0].title}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
+                    "content": "<p>Added task <a href=\"\/modules\/tasks\/{{vars.steps.Verify_Software_Source.uuid}}\" target=\"_blank\" rel=\"noopener\">{{vars.steps.Verify_Software_Source.name}}<\/a> to <strong>'Verify Software Source'<\/strong> <\/p>",
                     "records": "{{vars.input.records[0]['@id']}}",
                     "parentstepid": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c"
                 },

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -5299,8 +5299,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Approver Approval To Implement Task Complete",
-            "description": "Comment on assets as Approver Approval To Implement task completed",
+            "name": "Insert Comment Approver Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5328,8 +5328,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Assignee Approval To Implement Task Complete",
-            "description": "Comment on assets as Assignee Approval To Implement task completed",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5357,8 +5357,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Identify Security Control Task Complete",
-            "description": "Comment on assets as Identify Security Control task completed",
+            "name": "Insert Comment Identify Security Control Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5386,8 +5386,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Implement Change Task Complete",
-            "description": "Comment on assets as Implement Change task completed",
+            "name": "Insert Comment Implement Change Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5415,8 +5415,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Update Baseline Task Complete",
-            "description": "Comment on assets as Update Baseline task completed",
+            "name": "Insert Comment Update Baseline Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5444,8 +5444,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Security Controls Task Complete",
-            "description": "Comment on assets as Verify Security Controls task completed",
+            "name": "Insert Comment Verify Security Controls Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5473,8 +5473,8 @@
         },
         {
             "@type": "WorkflowStep",
-            "name": "Verify Software Source Task Complete",
-            "description": "Comment on assets as Verify Software Source task completed",
+            "name": "Insert Comment Verify Software Source Task Complete",
+            "description": null,
             "arguments": {
                 "resource": {
                     "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
@@ -5902,7 +5902,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement -> Approver Approval To Implement Task Complete",
+            "name": "Approver Approval To Implement -> Insert Comment Approver Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
             "sourceStep": "\/api\/3\/workflow_steps\/6c197eae-ca1d-4bb1-a827-74eb15544350",
             "label": null,
@@ -5922,7 +5922,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement -> Assignee Approval To Implement Task Complete",
+            "name": "Assignee Approval To Implement -> Insert Comment Assignee Approval To Implement Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
             "sourceStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
             "label": null,
@@ -5952,7 +5952,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Approver Approval To Implement Task Complete -> Implement Change",
+            "name": "Insert Comment Approver Approval To Implement Task Complete -> Implement Change",
             "targetStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "sourceStep": "\/api\/3\/workflow_steps\/1d429dec-82c1-4c70-876c-f3d85673fb03",
             "label": null,
@@ -5962,7 +5962,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Assignee Approval To Implement Task Complete -> Is Approver Assigned",
+            "name": "Insert Comment Assignee Approval To Implement Task Complete -> Is Approver Assigned",
             "targetStep": "\/api\/3\/workflow_steps\/dff61683-3b49-433d-b860-e4e24ad434fa",
             "sourceStep": "\/api\/3\/workflow_steps\/d3b805d0-19ec-4366-bdca-c7e97cde6eb1",
             "label": null,
@@ -5972,7 +5972,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control Task Complete -> Verify Software Source",
+            "name": "Insert Comment Identify Security Control Task Complete -> Verify Software Source",
             "targetStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
             "sourceStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
             "label": null,
@@ -5982,7 +5982,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change Task Complete -> Verify Security Controls",
+            "name": "Insert Comment Implement Change Task Complete -> Verify Security Controls",
             "targetStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
             "sourceStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
             "label": null,
@@ -5992,7 +5992,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline Task Complete -> Mark Activity Closed",
+            "name": "Insert Comment Update Baseline Task Complete -> Mark Activity Closed",
             "targetStep": "\/api\/3\/workflow_steps\/263e0483-6dc0-478d-94d0-11444ac888ec",
             "sourceStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
             "label": null,
@@ -6002,7 +6002,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls Task Complete -> Update Baseline",
+            "name": "Insert Comment Verify Security Controls Task Complete -> Update Baseline",
             "targetStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
             "sourceStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
             "label": null,
@@ -6012,7 +6012,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source Task Complete -> Assignee Approval To Implement",
+            "name": "Insert Comment Verify Software Source Task Complete -> Assignee Approval To Implement",
             "targetStep": "\/api\/3\/workflow_steps\/713a50b8-00ef-4251-acdf-895fcafc356b",
             "sourceStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
             "label": null,
@@ -6042,7 +6042,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Identify Security Control -> Identify Security Control Task Complete",
+            "name": "Identify Security Control -> Insert Comment Identify Security Control Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/38b23a3c-cdff-446f-ac5a-3a65bbf6fb57",
             "sourceStep": "\/api\/3\/workflow_steps\/e477b249-9fbd-4dc9-a2a0-c3f16957c28c",
             "label": null,
@@ -6052,7 +6052,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Implement Change -> Implement Change Task Complete",
+            "name": "Implement Change -> Insert Comment Implement Change Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/514c0107-2375-44db-b504-6f6f1363f22e",
             "sourceStep": "\/api\/3\/workflow_steps\/9a65d6ea-2638-44cb-9187-f0e894eceb69",
             "label": null,
@@ -6072,7 +6072,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Update Baseline -> Update Baseline Task Complete",
+            "name": "Update Baseline -> Insert Comment Update Baseline Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/c6a0e667-a8c5-46d4-998d-911fddcbe125",
             "sourceStep": "\/api\/3\/workflow_steps\/4c1261e6-9641-4329-8b6b-786a617af772",
             "label": null,
@@ -6082,7 +6082,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Security Controls -> Verify Security Controls Task Complete",
+            "name": "Verify Security Controls -> Insert Comment Verify Security Controls Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/e7b2c68e-0b25-439d-9076-861bd3e6baec",
             "sourceStep": "\/api\/3\/workflow_steps\/a90b9be1-45e9-4028-b130-d9d0b66dcf23",
             "label": null,
@@ -6092,7 +6092,7 @@
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Verify Software Source -> Verify Software Source Task Complete",
+            "name": "Verify Software Source -> Insert Comment Verify Software Source Task Complete",
             "targetStep": "\/api\/3\/workflow_steps\/fca39afc-527d-4b42-8106-5affd522c9d6",
             "sourceStep": "\/api\/3\/workflow_steps\/323597e4-aa88-453d-9c1b-497761fcde7a",
             "label": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Scenario - OT - Asset Change Activity.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Scenario - OT - Asset Change Activity.json
@@ -17,7 +17,7 @@
     "steps": [
         {
             "@type": "WorkflowStep",
-            "name": "Add New Asset",
+            "name": "Add New Cyber Asset",
             "description": null,
             "arguments": {
                 "resource": {
@@ -164,7 +164,7 @@
                     "product": "Stratix 5950",
                     "category": "\/api\/3\/picklists\/e231a1fb-166b-40b4-9c9f-1a71d5515db3",
                     "hostname": "Stratix 5950-RW41",
-                    "__replace": "false",
+                    "__replace": "true",
                     "assetType": "\/api\/3\/picklists\/7630b182-4930-4f97-beec-3c3a5372cb3b",
                     "assetClass": "\/api\/3\/picklists\/00cb224e-4198-4547-bbcb-a90bb9a60806",
                     "macAddress": "00:12:D1:7F:01:47",

--- a/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Create Alerts Record.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Scenario - OT - Create Alerts Record.json
@@ -13,15 +13,58 @@
     "synchronous": false,
     "collection": "\/api\/3\/workflow_collections\/fb4aa534-4bfc-4196-b509-96ef02fb9270",
     "versions": [],
-    "triggerStep": "\/api\/3\/workflow_steps\/7926edf0-c57d-4b36-9ad0-058bdddd4353",
+    "triggerStep": "\/api\/3\/workflow_steps\/7013344b-f0c6-4a93-bc32-3c86cd386773",
     "steps": [
+        {
+            "@type": "WorkflowStep",
+            "name": "Check OT Asset Simulation",
+            "description": null,
+            "arguments": {
+                "query": {
+                    "sort": [],
+                    "limit": 30,
+                    "logic": "AND",
+                    "filters": [
+                        {
+                            "type": "primitive",
+                            "field": "title",
+                            "value": "OT - Add Sample Assets",
+                            "operator": "eq",
+                            "_operator": "eq"
+                        }
+                    ]
+                },
+                "module": "scenario?$limit=30",
+                "step_variables": []
+            },
+            "status": null,
+            "top": "300",
+            "left": "218",
+            "stepType": "\/api\/3\/workflow_step_types\/b593663d-7d13-40ce-a3a3-96dece928770",
+            "group": null,
+            "uuid": "b8c39060-7bae-45bd-b3df-7944a945d22d"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Configuration",
+            "description": null,
+            "arguments": {
+                "recordIRI": "[]"
+            },
+            "status": null,
+            "top": "165",
+            "left": "218",
+            "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
+            "group": null,
+            "uuid": "a3e375b8-e7e8-45e1-8ff7-3f9e256bdeec"
+        },
         {
             "@type": "WorkflowStep",
             "name": "Create Alerts Record",
             "description": null,
             "arguments": {
                 "for_each": {
-                    "item": "{{vars.data}}",
+                    "item": "{{vars.alertList}}",
                     "__bulk": true,
                     "parallel": false,
                     "condition": "",
@@ -57,14 +100,84 @@
                 "fieldOperation": {
                     "recordTags": "Overwrite"
                 },
-                "step_variables": []
+                "step_variables": {
+                    "__dummy": "{{vars.recordIRI.extend(vars.steps.Create_Alerts_Record | json_query('[*][\"@id\"][]'))}}"
+                }
             },
             "status": null,
-            "top": "300",
-            "left": "125",
+            "top": "975",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/2597053c-e718-44b4-8394-4d40fe26d357",
             "group": null,
-            "uuid": "bddbf060-234e-4217-92cb-15bee08026d9"
+            "uuid": "940b63b8-a1fe-4504-8bc7-d1195c1ec733"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Create Assets Record",
+            "description": null,
+            "arguments": {
+                "for_each": {
+                    "item": "{{vars.assetList}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "arguments": {
+                    "assetRecord": "{{vars.item}}"
+                },
+                "apply_async": false,
+                "step_variables": {
+                    "recordIRI": "{{vars.steps.Create_Assets_Record| json_query('[*][\"@id\"][]')}}"
+                },
+                "pass_parent_env": false,
+                "pass_input_record": false,
+                "workflowReference": "\/api\/3\/workflows\/d6017f29-92f5-464f-b41b-e55f0f4d0298"
+            },
+            "status": null,
+            "top": "860",
+            "left": "540",
+            "stepType": "\/api\/3\/workflow_step_types\/74932bdc-b8b6-4d24-88c4-1a4dfbc524f3",
+            "group": null,
+            "uuid": "faae9f57-541b-4bce-8c70-15df3441808b"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Get Asset Data From CSV File",
+            "description": null,
+            "arguments": {
+                "name": "CSV Data Management",
+                "params": {
+                    "input": "Attachment IRI",
+                    "value": "\/api\/3\/attachments\/27e7ad03-7746-46c4-9580-81b9842cbe91",
+                    "filter": "{{vars.item}}",
+                    "columnNames": "",
+                    "filterInput": "On Specified Values",
+                    "recordBatch": "",
+                    "deDupValuesOn": "",
+                    "filterColumnName": "IP Address",
+                    "saveAsAttachment": "",
+                    "numberOfRowsToSkip": ""
+                },
+                "version": "1.2.0",
+                "for_each": {
+                    "item": "{{vars.ipList}}",
+                    "parallel": false,
+                    "condition": ""
+                },
+                "connector": "csv-data-management",
+                "operation": "extract_data_from_csv",
+                "operationTitle": "Extract Data from Single CSV",
+                "pickFromTenant": false,
+                "step_variables": {
+                    "data": "{{vars.steps.Get_Data_From_CSV_File.data['records']| replace('N\/A', None)}}",
+                    "assetList": "{{vars.steps.Get_Asset_Data_From_CSV_File | json_query('[*][data][][records][][]') | replace('N\/A', None)}}"
+                }
+            },
+            "status": null,
+            "top": "700",
+            "left": "540",
+            "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
+            "group": null,
+            "uuid": "6c4c0862-cde4-428e-93f9-5005e4007ff9"
         },
         {
             "@type": "WorkflowStep",
@@ -88,29 +201,58 @@
                 "operationTitle": "Extract Data from Single CSV",
                 "pickFromTenant": false,
                 "step_variables": {
-                    "data": "{{vars.steps.Get_Data_From_CSV_File.data['records'] | replace('N\/A', None)}}"
+                    "ipList": "{% set ipList = [] %}{% set _ = ipList.extend(vars.steps.Get_Data_From_CSV_File.data['records'] | json_query('[*][\"Source IP\"][]')) %}{% set _ = ipList.extend(vars.steps.Get_Data_From_CSV_File.data['records'] | json_query('[*][\"Destination IP\"][]')) %}{{ipList | unique}}",
+                    "alertList": "{{vars.steps.Get_Data_From_CSV_File.data['records'] | replace('N\/A', None)}}"
                 }
             },
             "status": null,
-            "top": "165",
-            "left": "125",
+            "top": "435",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/0bfed618-0316-11e7-93ae-92361f002671",
             "group": null,
-            "uuid": "1507d914-bc88-4e4a-b207-cf87d3cca9a4"
+            "uuid": "d99ffe10-d946-4085-8f57-2b32b684e8ec"
+        },
+        {
+            "@type": "WorkflowStep",
+            "name": "Is OT Asset Simulated",
+            "description": null,
+            "arguments": {
+                "conditions": [
+                    {
+                        "option": "No",
+                        "default": true,
+                        "step_iri": "\/api\/3\/workflow_steps\/6c4c0862-cde4-428e-93f9-5005e4007ff9",
+                        "step_name": "Get Asset Data From CSV File"
+                    },
+                    {
+                        "option": "Yes",
+                        "step_iri": "\/api\/3\/workflow_steps\/940b63b8-a1fe-4504-8bc7-d1195c1ec733",
+                        "condition": "{{ vars.steps.Check_OT_Asset_Simulation[0].createdAlertsID != None }}",
+                        "step_name": "Create Alerts Record"
+                    }
+                ],
+                "step_variables": []
+            },
+            "status": null,
+            "top": "570",
+            "left": "218",
+            "stepType": "\/api\/3\/workflow_step_types\/12254cf5-5db7-4b1a-8cb1-3af081924b28",
+            "group": null,
+            "uuid": "af8e2289-7b62-4d58-9197-cf39c72d9285"
         },
         {
             "@type": "WorkflowStep",
             "name": "Output",
             "description": null,
             "arguments": {
-                "@id": "{{vars.steps.Create_Alerts_Record | json_query('[*][\"@id\"][]')}}"
+                "@id": "{{vars.recordIRI}}"
             },
             "status": null,
-            "top": "435",
-            "left": "125",
+            "top": "1110",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/04d0cf46-b6a8-42c4-8683-60a7eaa69e8f",
             "group": null,
-            "uuid": "72c0d905-ccef-4794-b79c-c9ed6d41bcce"
+            "uuid": "1b5f8b31-4ee4-4f93-a325-2853c00430a0"
         },
         {
             "@type": "WorkflowStep",
@@ -125,42 +267,102 @@
             },
             "status": null,
             "top": "30",
-            "left": "125",
+            "left": "218",
             "stepType": "\/api\/3\/workflow_step_types\/b348f017-9a94-471f-87f8-ce88b6a7ad62",
             "group": null,
-            "uuid": "7926edf0-c57d-4b36-9ad0-058bdddd4353"
+            "uuid": "7013344b-f0c6-4a93-bc32-3c86cd386773"
         }
     ],
     "routes": [
         {
             "@type": "WorkflowRoute",
+            "name": "Check OT Asset Simulation -> Get Data From CSV File",
+            "targetStep": "\/api\/3\/workflow_steps\/d99ffe10-d946-4085-8f57-2b32b684e8ec",
+            "sourceStep": "\/api\/3\/workflow_steps\/b8c39060-7bae-45bd-b3df-7944a945d22d",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "6b7468b7-8c0c-4f64-831d-a752ca153fd3"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Configuration -> Check OT Asset Simulation",
+            "targetStep": "\/api\/3\/workflow_steps\/b8c39060-7bae-45bd-b3df-7944a945d22d",
+            "sourceStep": "\/api\/3\/workflow_steps\/a3e375b8-e7e8-45e1-8ff7-3f9e256bdeec",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "d4b5316b-aaa8-40ed-aa7b-7b1362d2cecf"
+        },
+        {
+            "@type": "WorkflowRoute",
             "name": "Create Alert -> Output",
-            "targetStep": "\/api\/3\/workflow_steps\/72c0d905-ccef-4794-b79c-c9ed6d41bcce",
-            "sourceStep": "\/api\/3\/workflow_steps\/bddbf060-234e-4217-92cb-15bee08026d9",
+            "targetStep": "\/api\/3\/workflow_steps\/1b5f8b31-4ee4-4f93-a325-2853c00430a0",
+            "sourceStep": "\/api\/3\/workflow_steps\/940b63b8-a1fe-4504-8bc7-d1195c1ec733",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "b07d0d79-e278-467b-a181-c6928fc21cae"
+            "uuid": "fa0e39a1-e6cf-459d-9904-e010ba6616d0"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Get Data From CSV File -> Create Alerts Record",
-            "targetStep": "\/api\/3\/workflow_steps\/bddbf060-234e-4217-92cb-15bee08026d9",
-            "sourceStep": "\/api\/3\/workflow_steps\/1507d914-bc88-4e4a-b207-cf87d3cca9a4",
+            "name": "Create Assets Record -> Create Alerts Record",
+            "targetStep": "\/api\/3\/workflow_steps\/940b63b8-a1fe-4504-8bc7-d1195c1ec733",
+            "sourceStep": "\/api\/3\/workflow_steps\/faae9f57-541b-4bce-8c70-15df3441808b",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "7b2f4b6f-d690-4948-8cd1-33e13ea680b6"
+            "uuid": "a3d51711-f672-4fba-8dc5-402de6b55764"
         },
         {
             "@type": "WorkflowRoute",
-            "name": "Start -> asd",
-            "targetStep": "\/api\/3\/workflow_steps\/1507d914-bc88-4e4a-b207-cf87d3cca9a4",
-            "sourceStep": "\/api\/3\/workflow_steps\/7926edf0-c57d-4b36-9ad0-058bdddd4353",
+            "name": "Get Asset Data From CSV File -> Create Assets Record",
+            "targetStep": "\/api\/3\/workflow_steps\/faae9f57-541b-4bce-8c70-15df3441808b",
+            "sourceStep": "\/api\/3\/workflow_steps\/6c4c0862-cde4-428e-93f9-5005e4007ff9",
             "label": null,
             "isExecuted": false,
             "group": null,
-            "uuid": "0cc6d1d6-5f33-401f-a54c-b9fab1ccbdbc"
+            "uuid": "8182cd09-8cc4-472b-b97a-e35e54f9aadf"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Get Data From CSV File -> Is OT Asset Simulated",
+            "targetStep": "\/api\/3\/workflow_steps\/af8e2289-7b62-4d58-9197-cf39c72d9285",
+            "sourceStep": "\/api\/3\/workflow_steps\/d99ffe10-d946-4085-8f57-2b32b684e8ec",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ba033e5c-cc4a-44e5-901b-6c31c93c82b0"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is OT Asset Simulated -> Create Alerts Record",
+            "targetStep": "\/api\/3\/workflow_steps\/940b63b8-a1fe-4504-8bc7-d1195c1ec733",
+            "sourceStep": "\/api\/3\/workflow_steps\/af8e2289-7b62-4d58-9197-cf39c72d9285",
+            "label": "Yes",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "ee69ae76-e8b9-4f32-a598-2536073aec07"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Is OT Asset Simulated -> Get Asset Data From CSV File",
+            "targetStep": "\/api\/3\/workflow_steps\/6c4c0862-cde4-428e-93f9-5005e4007ff9",
+            "sourceStep": "\/api\/3\/workflow_steps\/af8e2289-7b62-4d58-9197-cf39c72d9285",
+            "label": "No",
+            "isExecuted": false,
+            "group": null,
+            "uuid": "014f9ab0-e32f-4e46-8f12-f29131f7f24f"
+        },
+        {
+            "@type": "WorkflowRoute",
+            "name": "Start -> Configuration",
+            "targetStep": "\/api\/3\/workflow_steps\/a3e375b8-e7e8-45e1-8ff7-3f9e256bdeec",
+            "sourceStep": "\/api\/3\/workflow_steps\/7013344b-f0c6-4a93-bc32-3c86cd386773",
+            "label": null,
+            "isExecuted": false,
+            "group": null,
+            "uuid": "e3c7a72f-48a8-4e44-8573-96c8a20c08dd"
         }
     ],
     "groups": [],


### PR DESCRIPTION
Descriptions:
1. 0931187 - OT_asset_management: Task marked completed from asset change activity should be listed in the collaboration tab of asset
2. 0931189 - OT asset management: Asset change activity comments needs to be reformatted.
3. 0931205 - OT asset management: Need to add the comment in collaboration tab on cancellation of add new task from template.
4. 0931209 - OT asset management: Scenario - OT - Asset Change Activity PB  changes.
5. 0931708 - OT_asset_managment: Need to provide an appropriate error message if user runs Alert scenario prior to asset scenario.

Fix:
1. Added comment on assets on completing task under playbook "Add Cyber Asset", "High Impact Baseline Change", "Medium Impact Baseline Change", "Remove Cyber Asset", "Replace Cyber Asset", and "Modify Cyber Asset"
2. Reformatted task comment on Asset Change Activity record.
3. Added comment if "Add Task Template" got cancelled.
4. Changed step name from "Add New Asset" to "Add new Cyber Asset" and updated uniqueness constraint.
5. Added Logic to check if OT Sample if simulated or not. If not then create sample assets related to Alert in OT - Add Sample Alerts

