### PR TITLE
Bug Fixes: 0935509, 0935522

### DIFF
--- a/docs/contents.md
+++ b/docs/contents.md
@@ -39,11 +39,11 @@ The **OT - Asset Management** solution pack contains the following resources.
 
 ## Picklist
 
-| Name            |
-| :-------------- |
-| ActivityStatus  |
-| AssetChangeType |
-| AssetCategory   |
+| Name            | Description                                |
+| :-------------- | :----------------------------------------- |
+| ActivityStatus  | Contains the Asset Change Activity status. |
+| AssetChangeType | Contains the Asset Change Activity type.   |
+| AssetCategory   | Contains the OT related assets values.     |
 
 ## Report
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -27,15 +27,11 @@ The simulation mode has some sample data that helps you get a better understandi
 
     - This scenario adds 86 different sample OT Assets (different Levels, Types etc.) for testing dashboards, use case playbooks, reports and other actions.<br>
 
-    >**NOTE**: Ensure you run this **OT - Add Sample Assets** Scenario prior to running the **OT - Add Sample Alerts**, for facilitating the correlations of Alerts and Asset records.
-
 2. **OT - Add Sample Alerts**
 
     - Browse to `Simulations` > `OT - Add Sample Alerts` scenario and click **Simulate Scenario**.
 
     - This scenario adds 12 well populated sample OT Alerts for testing dashboards, use case playbooks, reports and other actions.<br>
-
-    >**NOTE**: Ensure you run the **OT - Add Sample Assets** Scenario prior to this, for facilitating the correlations of Alerts and Asset records.
 
 3. **OT - Stuxnet Attack Scenario**
 

--- a/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Add Cyber Asset.json
@@ -46,8 +46,8 @@
                 "step_variables": []
             },
             "status": null,
-            "top": "1520",
-            "left": "820",
+            "top": "1515",
+            "left": "568",
             "stepType": "\/api\/3\/workflow_step_types\/dc6ac63d-c5a5-472f-9eb4-6b18473a98b8",
             "group": null,
             "uuid": "a203fe02-2ea7-4ace-85d3-680ee2de15b1"
@@ -5507,14 +5507,6 @@
             "arguments": {
                 "params": [],
                 "version": "3.2.4",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5552,8 +5544,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/High Impact Baseline Change.json
@@ -7287,14 +7287,6 @@
             "arguments": {
                 "params": [],
                 "version": "3.2.4",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -7332,8 +7324,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Medium Impact Baseline Change.json
@@ -5495,14 +5495,6 @@
             "arguments": {
                 "params": [],
                 "version": "3.2.4",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5540,8 +5532,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Modify Cyber Asset.json
@@ -5507,14 +5507,6 @@
             "arguments": {
                 "params": [],
                 "version": "3.2.4",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5552,8 +5544,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Remove Cyber Asset.json
@@ -5507,14 +5507,6 @@
             "arguments": {
                 "params": [],
                 "version": "3.2.4",
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "connector": "cyops_utilities",
                 "operation": "no_op",
                 "operationTitle": "Utils: No Operation",
@@ -5552,8 +5544,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
+++ b/playbooks/02 - Use Case - Asset Change Activity/Replace Cyber Asset.json
@@ -5506,14 +5506,6 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Add Task from Template'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "no_op",
@@ -5552,8 +5544,7 @@
                 "module": "asset_change_activities?$limit=30&$relationships=true&$fsr_max_relation_count=100",
                 "checkboxFields": true,
                 "step_variables": {
-                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}",
-                    "loggedInUserName": "{{(vars.currentUser | fromIRI).firstname }} {{(vars.currentUser | fromIRI).lastname}}"
+                    "assetIRI": "{{vars.steps.Get_Correlated_Asset[0].assets | json_query('[*][\"@id\"][]')}}"
                 }
             },
             "status": null,

--- a/playbooks/02 - Use Case - IT OT Asset Management/Quarantine Asset and Raise Ticket.json
+++ b/playbooks/02 - Use Case - IT OT Asset Management/Quarantine Asset and Raise Ticket.json
@@ -38,14 +38,6 @@
             "description": null,
             "arguments": {
                 "params": [],
-                "message": {
-                    "tags": [],
-                    "type": "\/api\/3\/picklists\/ff599189-3eeb-4c86-acb0-a7915e85ac3b",
-                    "tenant": "",
-                    "thread": false,
-                    "content": "<p><strong>'Quarantine Asset and Raise Ticket'<\/strong> playbook triggered and cancelled by <em>{{vars.loggedInUserName}}<\/em>.<\/p>",
-                    "records": "{{vars.input.records[0]['@id']}}"
-                },
                 "version": "3.2.4",
                 "connector": "cyops_utilities",
                 "operation": "no_op",


### PR DESCRIPTION
Descriptions:
1. OT asset management: Asset categories additional entries needs to be mentioned in documentation.
2. OT asset management: Please remove the note from documentation OT asset sample needs to run before OT alert sample.
3. Removed Cancel log from different type playbook's of "Asset Change Activity" and from "Quarantine Asset and Raise Ticket"

#### Fix:
1. Added description for picklists under content.md
2. Remove the note from documentation OT asset sample needs to run before OT alert sample under usage.md

